### PR TITLE
Use `.env` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# MAC related stuff
+.DS_STORE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "SimpleITK",
     "wandb",
     "weave",
+    "python-dotenv==1.0.0"
 ]
 
 [project.optional-dependencies]

--- a/yucca/documentation/tutorials/environment_variables.md
+++ b/yucca/documentation/tutorials/environment_variables.md
@@ -1,15 +1,14 @@
 # Setting up environment variables
 
-Edit the .bashrc file (found in the home folder)
+To setup environment variables add the following `.env` file to the root Yucca folder:
 
-and add the following lines (editing the paths to your liking):
 ```
-export yucca_raw_data="/path/to/YuccaData/yucca_raw_data"
-export yucca_preprocessed="/path/to/YuccaData/yucca_preprocessed"
-export yucca_models="/path/to/YuccaData/yucca_models"
-export yucca_results="/path/to/YuccaData/yucca_results"
+YUCCA_RAW_DATA=/path/to/yucca_data/raw_data
+YUCCA_PREPROCESSED="/path/to/yucca_data/preprocessed"
+YUCCA_MODELS="/path/to/yucca_data/models"
+YUCCA_RESULTS="/path/to/yucca_data/results"
 ```
 
 What's the purpose of this?
 
-To the maximum extent possible we don't want hardcoded paths. It is simply bad practice and completely lacks scalability. Using environment variables allows us to limit hardcoded paths to the Task Conversion scripts. 
+To the maximum extent possible we don't want hardcoded paths. It is simply bad practice and completely lacks scalability. Using environment variables allows us to limit hardcoded paths to the Task Conversion scripts.

--- a/yucca/paths.py
+++ b/yucca/paths.py
@@ -2,12 +2,16 @@
 PLEASE READ YUCCA/DOCUMENTATION/TUTORIALS/ENVIRONMENT_VARIABLES.MD FOR INFORMATION ON HOW TO SET THIS UP
 """
 import os
+from dotenv import load_dotenv
+
 from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p
 
-yucca_raw_data = os.environ['yucca_raw_data'] if "yucca_raw_data" in os.environ.keys() else None
-yucca_preprocessed = os.environ['yucca_preprocessed'] if "yucca_preprocessed" in os.environ.keys() else None
-yucca_models = os.environ['yucca_models'] if "yucca_models" in os.environ.keys() else None
-yucca_results = os.environ['yucca_results'] if "yucca_results" in os.environ.keys() else None
+assert load_dotenv()
+
+yucca_raw_data = os.environ['YUCCA_RAW_DATA'] if "YUCCA_RAW_DATA" in os.environ.keys() else None
+yucca_preprocessed = os.environ['YUCCA_PREPROCESSED'] if "YUCCA_PREPROCESSED" in os.environ.keys() else None
+yucca_models = os.environ['YUCCA_MODELS'] if "YUCCA_MODELS" in os.environ.keys() else None
+yucca_results = os.environ['YUCCA_RESULTS'] if "YUCCA_RESULTS" in os.environ.keys() else None
 
 if yucca_raw_data is not None:
     maybe_mkdir_p(yucca_raw_data)


### PR DESCRIPTION
This PR 

1. handles environment variables using a `.env` file. 
2. changes environment variables to capitalised, since this is a common convention (i.e. https://google.github.io/styleguide/shellguide.html#constants-and-environment-variable-names). 