### PR TITLE
Update inference

### DIFF
--- a/yucca/evaluation/YuccaEvaluator.py
+++ b/yucca/evaluation/YuccaEvaluator.py
@@ -20,6 +20,7 @@ from yuccalib.evaluation.metrics import (
 from yuccalib.evaluation.obj_metrics import get_obj_stats_for_label
 from yucca.paths import yucca_raw_data
 from weave.monitoring import StreamTable
+from tqdm import tqdm
 
 
 class YuccaEvaluator(object):
@@ -123,7 +124,7 @@ class YuccaEvaluator(object):
         for label in self.labels:
             meandict[label] = {k: [] for k in list(self.metrics.keys()) + self.obj_metrics}
 
-        for case in self.pred_subjects:
+        for case in tqdm(self.pred_subjects, desc="Evaluation"):
             casedict = {}
             predpath = join(self.folder_with_predictions, case)
             gtpath = join(self.folder_with_ground_truth, case)

--- a/yucca/evaluation/YuccaEvaluator.py
+++ b/yucca/evaluation/YuccaEvaluator.py
@@ -124,7 +124,7 @@ class YuccaEvaluator(object):
         for label in self.labels:
             meandict[label] = {k: [] for k in list(self.metrics.keys()) + self.obj_metrics}
 
-        for case in tqdm(self.pred_subjects, desc="Evaluation"):
+        for case in tqdm(self.pred_subjects, desc="Evaluating"):
             casedict = {}
             predpath = join(self.folder_with_predictions, case)
             gtpath = join(self.folder_with_ground_truth, case)

--- a/yucca/preprocessing/YuccaPreprocessor.py
+++ b/yucca/preprocessing/YuccaPreprocessor.py
@@ -452,7 +452,7 @@ class YuccaPreprocessor(object):
             f"but is: {images.shape[2:]}"
         )
         shape = images.shape[2:]
-        if len(pad) > 5:
+        if len(pad) == 6:
             images = images[
                 :,
                 :,
@@ -460,7 +460,7 @@ class YuccaPreprocessor(object):
                 pad[2] : shape[1] - pad[3],
                 pad[4] : shape[2] - pad[5],
             ]
-        elif len(pad) < 5:
+        elif len(pad) == 4:
             images = images[:, :, pad[0] : shape[0] - pad[1], pad[2] : shape[1] - pad[3]]
 
         assert np.all(images.shape[2:] == image_properties["resampled_transposed_shape"]), (

--- a/yucca/preprocessing/YuccaPreprocessor.py
+++ b/yucca/preprocessing/YuccaPreprocessor.py
@@ -447,59 +447,55 @@ class YuccaPreprocessor(object):
         shape_after_crop_transposed = shape_after_crop[self.transpose_forward]
         pad = image_properties["padding"]
 
-        for b in range(images.shape[0]):
-            for c in range(images.shape[1]):
-                image = images[b, c]
-                assert np.all(image.shape == image_properties["padded_shape"]), (
-                    f"Reversing padding: "
-                    f"image should be of shape: {image_properties['padded_shape']}"
-                    f"but is: {image.shape}"
+        assert np.all(images.shape[2:] == image_properties["padded_shape"]), (
+            f"Reversing padding: "
+            f"image should be of shape: {image_properties['padded_shape']}"
+            f"but is: {images.shape[2:]}"
+        )
+        print(torch.unique(torch.argmax(images, 1)))
+        shape = images.shape[2:]
+        if len(pad) > 5:
+            images = images[
+                pad[0] : shape[0] - pad[1],
+                pad[2] : shape[1] - pad[3],
+                pad[4] : shape[2] - pad[5],
+            ]
+        elif len(pad) < 5:
+            images = images[pad[0] : shape[0] - pad[1], pad[2] : shape[1] - pad[3]]
+
+        assert np.all(shape == image_properties["resampled_transposed_shape"]), (
+            f"Reversing resampling and tranposition: "
+            f"image should be of shape: {image_properties['resampled_transposed_shape']}"
+            f"but is: {shape}"
+        )
+        # Here we Interpolate the array to the original size. The shape starts as [H, W (,D)]. For Torch functionality it is changed to [B, C, H, W (,D)].
+        # Afterwards it's squeezed back into [H, W (,D)] and transposed to the original direction.
+        images = torch.squeeze(F.interpolate(images, size=shape_after_crop_transposed.tolist(), mode="trilinear")).permute(
+            self.transpose_backward
+        )
+
+        assert np.all(shape == image_properties["cropped_shape"]), (
+            f"Reversing cropping: " f"image should be of shape: {image_properties['cropped_shape']}" f"but is: {shape}"
+        )
+
+        if self.plans["crop_to_nonzero"]:
+            bbox = image_properties["nonzero_box"]
+            if len(bbox) > 5:
+                slices = (
+                    slice(None),
+                    slice(c, c + 1),
+                    slice(bbox[0], bbox[1]),
+                    slice(bbox[2], bbox[3]),
+                    slice(bbox[4], bbox[5]),
                 )
-                shape = image.shape
-                if len(pad) > 5:
-                    image = image[
-                        pad[0] : shape[0] - pad[1],
-                        pad[2] : shape[1] - pad[3],
-                        pad[4] : shape[2] - pad[5],
-                    ]
-                elif len(pad) < 5:
-                    image = image[pad[0] : shape[0] - pad[1], pad[2] : shape[1] - pad[3]]
+            elif len(bbox) < 5:
+                slices = (slice(None), slice(c, c + 1), slice(bbox[0], bbox[1]), slice(bbox[2], bbox[3]))
+            canvas[slices] = images
+        else:
+            canvas = images
 
-                assert np.all(image.shape == image_properties["resampled_transposed_shape"]), (
-                    f"Reversing resampling and tranposition: "
-                    f"image should be of shape: {image_properties['resampled_transposed_shape']}"
-                    f"but is: {image.shape}"
-                )
-                # Here we Interpolate the array to the original size. The shape starts as [H, W (,D)]. For Torch functionality it is changed to [B, C, H, W (,D)].
-                # Afterwards it's squeezed back into [H, W (,D)] and transposed to the original direction.
-                image = torch.squeeze(
-                    F.interpolate(image[None, None], size=shape_after_crop_transposed.tolist(), mode="trilinear")
-                ).permute(self.transpose_backward)
-
-                assert np.all(image.shape == image_properties["cropped_shape"]), (
-                    f"Reversing cropping: "
-                    f"image should be of shape: {image_properties['cropped_shape']}"
-                    f"but is: {image.shape}"
-                )
-
-                if self.plans["crop_to_nonzero"]:
-                    bbox = image_properties["nonzero_box"]
-                    if len(bbox) > 5:
-                        slices = (
-                            slice(None),
-                            slice(c, c + 1),
-                            slice(bbox[0], bbox[1]),
-                            slice(bbox[2], bbox[3]),
-                            slice(bbox[4], bbox[5]),
-                        )
-                    elif len(bbox) < 5:
-                        slices = (slice(None), slice(c, c + 1), slice(bbox[0], bbox[1]), slice(bbox[2], bbox[3]))
-                    canvas[slices] = image
-                else:
-                    canvas = image
-
-                am = np.argmax(canvas.numpy(), 1)
-                print(am.shape)
-                print(np.unique(am))
-                print(np.unique(am[0]))
+        am = np.argmax(canvas.numpy(), 1)
+        print(am.shape)
+        print(np.unique(am))
+        print(np.unique(am[0]))
         return canvas.numpy()

--- a/yucca/run/run_inference.py
+++ b/yucca/run/run_inference.py
@@ -68,7 +68,14 @@ def main():
         action="store_true",
     )
     parser.add_argument(
-        "--do_tta",
+        "--profile",
+        help="Used to enable inference profiling",
+        default=False,
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--disable_tta",
         help="Used to enable test-time augmentations (mirroring)",
         default=False,
         action="store_true",
@@ -121,9 +128,11 @@ def main():
     dimensions = args.d
     folds = args.f
     planner = args.pl
+    profile = args.profile
     checkpoint = args.chk
     version = args.v
     ensemble = args.ensemble
+    disable_tta = args.disable_tta
     not_strict = args.not_strict
     save_softmax = args.save_softmax
     overwrite = args.overwrite
@@ -173,7 +182,13 @@ def main():
 
         print(f"{'Using manager: ':25} {manager_name}")
         manager = manager(
-            model_name=model, model_dimensions=dimensions, task=source_task, folds=folds, planner=planner, ckpt_path=modelfile
+            model_name=model,
+            model_dimensions=dimensions,
+            task=source_task,
+            folds=folds,
+            planner=planner,
+            ckpt_path=modelfile,
+            profile=profile,
         )
 
         # Setting up input paths and output paths
@@ -186,8 +201,8 @@ def main():
             source_task,
             model + "__" + dimensions,
             manager_name + "__" + planner,
-            folds,
-            version,
+            f"fold_{folds}",
+            f"version_{version}",
             checkpoint,
         )
 
@@ -200,6 +215,7 @@ def main():
 
         manager.predict_folder(
             inpath,
+            disable_tta,
             outpath,
             save_softmax=save_softmax,
             # overwrite=overwrite, # Commented out until overwrite arg is added in manager.

--- a/yucca/run/run_inference.py
+++ b/yucca/run/run_inference.py
@@ -54,7 +54,7 @@ def main():
     parser.add_argument(
         "-chk",
         help="Checkpoint to use for inference. Defaults to model_best.",
-        default="model_best",
+        default="best",
     )
     parser.add_argument(
         "-v",
@@ -141,7 +141,7 @@ def main():
 
     for planner in plans:
         path_to_versions = join(
-            yucca_models, source_task, model + "__" + dimensions, manager_name + "__" + planner, f"folds_{folds}"
+            yucca_models, source_task, model + "__" + dimensions, manager_name + "__" + planner, f"fold_{folds}"
         )
         if version is None:
             versions = [int(i.split("_")[-1]) for i in subdirs(path_to_versions, join=False)]
@@ -151,7 +151,7 @@ def main():
             source_task,
             model + "__" + dimensions,
             manager_name + "__" + planner,
-            f"folds_{folds}",
+            f"fold_{folds}",
             f"version_{version}",
             "checkpoints",
             checkpoint + ".ckpt",
@@ -171,7 +171,7 @@ def main():
         assert manager, f"searching for {manager_name} " f"but found: {manager}"
         assert issubclass(manager, (YuccaManager, YuccaLightningManager)), "Trainer is not a subclass of YuccaTrainer."
 
-        print(f"{'Using manager: ':25} {manager}")
+        print(f"{'Using manager: ':25} {manager_name}")
         manager = manager(
             model_name=model, model_dimensions=dimensions, task=source_task, folds=folds, planner=planner, ckpt_path=modelfile
         )
@@ -202,7 +202,7 @@ def main():
             inpath,
             outpath,
             save_softmax=save_softmax,
-            overwrite=overwrite,
+            # overwrite=overwrite, # Commented out until overwrite arg is added in manager.
         )
 
         folders_with_softmax.append(outpath)

--- a/yucca/training/trainers/YuccaLightningManager.py
+++ b/yucca/training/trainers/YuccaLightningManager.py
@@ -124,7 +124,7 @@ class YuccaLightningManager:
         self.model_module = YuccaLightningModule(
             configurator=configurator,
             step_logging=self.step_logging,
-            test_time_augmentation=not disable_tta if disable_tta else bool(augmenter.mirror_p_per_sample),
+            test_time_augmentation=not disable_tta if disable_tta is True else bool(augmenter.mirror_p_per_sample),
         )
 
         self.data_module = YuccaDataModule(

--- a/yucca/training/trainers/YuccaLightningManager.py
+++ b/yucca/training/trainers/YuccaLightningManager.py
@@ -84,6 +84,7 @@ class YuccaLightningManager:
     def initialize(
         self,
         stage: Literal["fit", "test", "predict"],
+        disable_tta: bool = False,
         pred_data_dir: str = None,
         save_softmax: bool = False,
         segmentation_output_dir: str = "./",
@@ -123,7 +124,7 @@ class YuccaLightningManager:
         self.model_module = YuccaLightningModule(
             configurator=configurator,
             step_logging=self.step_logging,
-            test_time_augmentation=bool(augmenter.mirror_p_per_sample),
+            test_time_augmentation=not disable_tta if disable_tta else bool(augmenter.mirror_p_per_sample),
         )
 
         self.data_module = YuccaDataModule(
@@ -159,20 +160,23 @@ class YuccaLightningManager:
     def predict_folder(
         self,
         input_folder,
+        disable_tta: bool = False,
         output_folder: str = yucca_results,
         save_softmax=False,
     ):
         self.initialize(
             stage="predict",
+            disable_tta=disable_tta,
             pred_data_dir=input_folder,
             segmentation_output_dir=output_folder,
             save_softmax=save_softmax,
         )
-        self.trainer.predict(
-            model=self.model_module,
-            dataloaders=self.data_module,
-            ckpt_path=self.ckpt_path,
-        )
+        with torch.inference_mode():
+            self.trainer.predict(
+                model=self.model_module,
+                dataloaders=self.data_module,
+                ckpt_path=self.ckpt_path,
+            )
 
 
 if __name__ == "__main__":

--- a/yucca/training/trainers/YuccaLightningModule.py
+++ b/yucca/training/trainers/YuccaLightningModule.py
@@ -124,38 +124,20 @@ class YuccaLightningModule(L.LightningModule):
     def predict_step(self, batch, batch_idx, dataloader_idx=0):
         case, case_id = batch
 
-        print(self.test_time_augmentation)
-        t0 = time()
-
         (
             case_preprocessed,
             case_properties,
         ) = self.preprocessor.preprocess_case_for_inference(case, self.patch_size)
 
-        t1 = time()
-
-        logits = (
-            self.model.predict(
-                mode=self.model_dimensions,
-                data=case_preprocessed,
-                patch_size=self.patch_size,
-                overlap=self.sliding_window_overlap,
-                mirror=self.test_time_augmentation,
-            )
-            .detach()
-            .cpu()
-            .numpy()
+        logits = self.model.predict(
+            mode=self.model_dimensions,
+            data=case_preprocessed,
+            patch_size=self.patch_size,
+            overlap=self.sliding_window_overlap,
+            mirror=self.test_time_augmentation,
         )
 
-        t2 = time()
-
         logits = self.preprocessor.reverse_preprocessing(logits, case_properties)
-
-        t3 = time()
-
-        print("pp: ", t1 - t0)
-        print("pred: ", t2 - t1)
-        print("re: ", t3 - t2)
         return {"logits": logits, "properties": case_properties, "case_id": case_id[0]}
 
     def configure_optimizers(self):


### PR DESCRIPTION
Inference overhaul for Lightning.
Minor changes include updating argument names and adding some nice to haves like progress bars etc.

Major changes include the preprocessing-reversion happening after predictions.

Previously inference was:
1. Preprocess case (numpy + CPU) - rather fast process. Ensures preprocessing is 100% the same as in training.
2. Predict (torch + GPU)
3. Reverse preprocessing and save output (numpy + CPU) - rather slow process, but this was handled by multiprocessing.

In lightning 3. is not easily implemented with multiprocessing (in a clean and nice way) and therefore becomes a big bottleneck. Therefore it is completely rewritten. This means 3 is now 2 steps:
3. Reverse preprocessing (torch + GPU)
4. Save output (numpy + CPU)

This reduces inference time by up to 10 times for high dimensional data (rather insignificant difference for very small arrays).