### PR TITLE
Update subject_ids collection in YuccaPreprocessor.py

### DIFF
--- a/yucca/preprocessing/YuccaPreprocessor.py
+++ b/yucca/preprocessing/YuccaPreprocessor.py
@@ -76,8 +76,9 @@ class YuccaPreprocessor(object):
         self.target_dir = join(yucca_preprocessed_data, self.task, self.plans["plans_name"])
         self.input_dir = join(yucca_raw_data, self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
-        self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
-        self.subject_ids = subfiles(join(self.input_dir, "labelsTr"), join=False)
+        self.subject_ids = [
+            file for file in subfiles(join(self.input_dir, "labelsTr"), join=False, prefix="") if not file.startswith(".")
+        ]
 
     def initialize_properties(self):
         """

--- a/yucca/preprocessing/YuccaPreprocessor.py
+++ b/yucca/preprocessing/YuccaPreprocessor.py
@@ -77,7 +77,7 @@ class YuccaPreprocessor(object):
         self.input_dir = join(yucca_raw_data, self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
         self.subject_ids = [
-            file for file in subfiles(join(self.input_dir, "labelsTr"), join=False, prefix="") if not file.startswith(".")
+            file for file in subfiles(join(self.input_dir, "labelsTr"), join=False) if not file.startswith(".")
         ]
 
     def initialize_properties(self):

--- a/yucca/preprocessing/YuccaPreprocessor.py
+++ b/yucca/preprocessing/YuccaPreprocessor.py
@@ -77,7 +77,7 @@ class YuccaPreprocessor(object):
         self.input_dir = join(yucca_raw_data, self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
-        self.subject_ids = subfiles(join(self.input_dir, "labelsTr"), suffix=self.image_extension, join=False)
+        self.subject_ids = subfiles(join(self.input_dir, "labelsTr"), join=False)
 
     def initialize_properties(self):
         """


### PR DESCRIPTION
@asbjrnmunk your latest change introduces a bug, this would only work if the image files are of the same format as the labels, which is a special case