### PR TITLE
Minor changes to config apis

### DIFF
--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -1,7 +1,7 @@
 def test_configurations():
     import os
     from yucca.training.configuration.configure_callbacks import get_callback_config
-    from yucca.training.configuration.configure_paths_and_version import get_path_and_version_config
+    from yucca.training.configuration.configure_paths_and_version import get_path_config
     from yucca.training.configuration.configure_plans import get_plan_config
     from yucca.training.configuration.configure_task import get_task_config
     from yucca.training.configuration.input_dimensions import get_input_dims
@@ -11,25 +11,10 @@ def test_configurations():
     task_config = get_task_config(task="Task000_Test")
     assert task_config is not None and isinstance(task_config.continue_from_most_recent, bool)
 
-    path_config = get_path_and_version_config(
-        ckpt_path=None,
-        continue_from_most_recent=task_config.continue_from_most_recent,
-        manager_name=task_config.manager_name,
-        model_dimensions=task_config.model_dimensions,
-        model_name=task_config.model_name,
-        planner_name=task_config.planner_name,
-        split_idx=task_config.split_idx,
-        task=task_config.task,
-    )
+    path_config = get_path_config(ckpt_path=None, task_config=task_config)
     assert path_config is not None and isinstance(path_config.version, int)
 
-    plan_config = get_plan_config(
-        ckpt_path=path_config.ckpt_path,
-        continue_from_most_recent=True,
-        plans_path=path_config.plans_path,
-        version=path_config.version,
-        version_dir=path_config.version_dir,
-    )
+    plan_config = get_plan_config(path_config=path_config, continue_from_most_recent=True)
     assert plan_config is not None and plan_config.task_type in ["classification", "segmentation", "unsupervised"]
 
     input_dims = get_input_dims(

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -4,7 +4,7 @@ def test_configurations():
     from yucca.training.configuration.configure_paths_and_version import get_path_config
     from yucca.training.configuration.configure_plans import get_plan_config
     from yucca.training.configuration.configure_task import get_task_config
-    from yucca.training.configuration.input_dimensions import get_input_dims
+    from yucca.training.configuration.input_dimensions import get_input_dims_config
     from yucca.training.configuration.split_data import get_split_config
     from yucca.paths import yucca_preprocessed_data
 
@@ -17,7 +17,7 @@ def test_configurations():
     plan_config = get_plan_config(path_config=path_config, continue_from_most_recent=True)
     assert plan_config is not None and plan_config.task_type in ["classification", "segmentation", "unsupervised"]
 
-    input_dims = get_input_dims(
+    input_dims = get_input_dims_config(
         plan=plan_config.plans,
         model_dimensions=task_config.model_dimensions,
         num_classes=plan_config.num_classes,

--- a/yucca/training/configuration/configure_paths_and_version.py
+++ b/yucca/training/configuration/configure_paths_and_version.py
@@ -28,11 +28,15 @@ class PathConfig:
         }
 
 
-def get_path_and_version_config(
-    ckpt_path, continue_from_most_recent, manager_name, model_dimensions, model_name, planner_name, split_idx, task
-):
+def get_path_config(ckpt_path: str, task_config: TaskConfig):
     save_dir, train_data_dir, version_dir, plans_path, version = setup_paths_and_version(
-        continue_from_most_recent, manager_name, model_dimensions, model_name, split_idx, task, planner_name
+        task_config.continue_from_most_recent,
+        task_config.manager_name,
+        task_config.model_dimensions,
+        task_config.model_name,
+        task_config.split_idx,
+        task_config.task,
+        task_config.planner_name,
     )
 
     return PathConfig(

--- a/yucca/training/configuration/configure_plans.py
+++ b/yucca/training/configuration/configure_plans.py
@@ -6,6 +6,7 @@ from typing import Union
 from yucca.paths import yucca_models, yucca_preprocessed_data
 from yucca.preprocessing.UnsupervisedPreprocessor import UnsupervisedPreprocessor
 from yucca.preprocessing.ClassificationPreprocessor import ClassificationPreprocessor
+from yucca.training.configuration.configure_paths_and_version import PathConfig
 from yucca.utils.files_and_folders import recursive_find_python_class
 
 
@@ -25,8 +26,14 @@ class PlanConfig:
         }
 
 
-def get_plan_config(ckpt_path: str, continue_from_most_recent: bool, plans_path: str, version: int, version_dir: str):
-    plans = setup_plans(ckpt_path, continue_from_most_recent, plans_path, version, version_dir)
+def get_plan_config(path_config: PathConfig, continue_from_most_recent: bool):
+    plans = setup_plans(
+        path_config.ckpt_path,
+        continue_from_most_recent,
+        path_config.plans_path,
+        path_config.version,
+        path_config.version_dir,
+    )
     task_type = setup_task_type(plans)
     num_classes = max(1, plans.get("num_classes") or len(plans["dataset_properties"]["classes"]))
     image_extension = plans.get("image_extension") or plans["dataset_properties"].get("image_extension") or "nii.gz"

--- a/yucca/training/configuration/input_dimensions.py
+++ b/yucca/training/configuration/input_dimensions.py
@@ -5,7 +5,7 @@ from yucca.network_architectures.utils.model_memory_estimation import find_optim
 
 
 @dataclass
-class InputDimensions:
+class InputDimensionsConfig:
     batch_size: int
     patch_size: Union[Tuple[int, int], Tuple[int, int, int]]
     num_modalities: int
@@ -18,7 +18,7 @@ class InputDimensions:
         }
 
 
-def get_input_dims(
+def get_input_dims_config(
     plan: dict,
     model_dimensions: Literal["2D", "3D"],
     num_classes: int,
@@ -84,7 +84,7 @@ def get_input_dims(
 
     print(f"Using batch size: {batch_size} and patch size: {patch_size}")
 
-    return InputDimensions(
+    return InputDimensionsConfig(
         batch_size=batch_size,
         patch_size=patch_size,
         num_modalities=num_modalities,

--- a/yucca/training/data_loading/YuccaDataModule.py
+++ b/yucca/training/data_loading/YuccaDataModule.py
@@ -3,7 +3,7 @@ import torchvision
 from typing import Literal
 from torch.utils.data import DataLoader, Sampler
 from batchgenerators.utilities.file_and_folder_operations import join
-from yucca.training.configuration.input_dimensions import InputDimensions
+from yucca.training.configuration.input_dimensions import InputDimensionsConfig
 from yucca.training.configuration.split_data import SplitConfig
 from yucca.training.configuration.configure_plans import PlanConfig
 from yucca.training.data_loading.YuccaDataset import YuccaTestDataset, YuccaTrainDataset
@@ -46,9 +46,9 @@ class YuccaDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        input_dims: InputDimensions,
+        input_dims_config: InputDimensionsConfig,
         plan_config: PlanConfig,
-        splits: SplitConfig,
+        splits_config: SplitConfig,
         split_idx: int,
         composed_train_transforms: torchvision.transforms.Compose = None,
         composed_val_transforms: torchvision.transforms.Compose = None,
@@ -60,12 +60,12 @@ class YuccaDataModule(pl.LightningDataModule):
     ):
         super().__init__()
         # extract parameters
-        self.batch_size = input_dims.batch_size
-        self.patch_size = input_dims.patch_size
+        self.batch_size = input_dims_config.batch_size
+        self.patch_size = input_dims_config.patch_size
         self.image_extension = plan_config.image_extension
         self.task_type = plan_config.task_type
-        self.train_split = splits.train(split_idx)
-        self.val_split = splits.val(split_idx)
+        self.train_split = splits_config.train(split_idx)
+        self.val_split = splits_config.val(split_idx)
 
         # Set by initialize()
         self.composed_train_transforms = composed_train_transforms

--- a/yucca/training/data_loading/YuccaDataModule.py
+++ b/yucca/training/data_loading/YuccaDataModule.py
@@ -46,6 +46,7 @@ class YuccaDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
+        train_data_dir: str,
         input_dims_config: InputDimensionsConfig,
         plan_config: PlanConfig,
         splits_config: SplitConfig,
@@ -55,7 +56,6 @@ class YuccaDataModule(pl.LightningDataModule):
         num_workers: int = 8,
         pred_data_dir: str = None,
         pre_aug_patch_size: list | tuple = None,
-        train_data_dir: str = None,
         sampler: Sampler = InfiniteRandomSampler,
     ):
         super().__init__()

--- a/yucca/training/managers/YuccaManager.py
+++ b/yucca/training/managers/YuccaManager.py
@@ -5,7 +5,7 @@ from yucca.training.augmentation.YuccaAugmentationComposer import YuccaAugmentat
 from yucca.training.configuration.split_data import get_split_config
 from yucca.training.configuration.configure_task import get_task_config
 from yucca.training.configuration.configure_callbacks import get_callback_config
-from yucca.training.configuration.configure_paths_and_version import get_path_and_version_config
+from yucca.training.configuration.configure_paths_and_version import get_path_config
 from yucca.training.configuration.configure_plans import get_plan_config
 from yucca.training.data_loading.YuccaDataModule import YuccaDataModule
 from yucca.training.lightning_modules.YuccaLightningModule import YuccaLightningModule
@@ -111,26 +111,15 @@ class YuccaManager:
             task=self.task,
         )
 
-        self.path_config = get_path_and_version_config(
-            ckpt_path=self.ckpt_path,
-            continue_from_most_recent=task_config.continue_from_most_recent,
-            manager_name=task_config.manager_name,
-            model_dimensions=task_config.model_dimensions,
-            model_name=task_config.model_name,
-            planner_name=task_config.planner_name,
-            split_idx=task_config.split_idx,
-            task=task_config.task,
-        )
+        self.path_config = get_path_config(ckpt_path=self.ckpt_path, task_config=task_config)
 
         plan_config = get_plan_config(
-            ckpt_path=self.path_config.ckpt_path,
+            path_config=self.path_config,
             continue_from_most_recent=task_config.continue_from_most_recent,
-            plans_path=self.path_config.plans_path,
-            version=self.path_config.version,
-            version_dir=self.path_config.version_dir,
         )
 
         splits = get_split_config(train_data_dir=self.path_config.train_data_dir, task=task_config.task)
+
         input_dims = get_input_dims(
             plan=plan_config.plans,
             model_dimensions=task_config.model_dimensions,

--- a/yucca/training/managers/YuccaManager.py
+++ b/yucca/training/managers/YuccaManager.py
@@ -118,7 +118,6 @@ class YuccaManager:
             path_config=self.path_config, continue_from_most_recent=task_config.continue_from_most_recent
         )
 
-        # TODO: Give it the plan config instead of plan
         input_dims_config = get_input_dims_config(
             plan=plan_config.plans,
             model_dimensions=task_config.model_dimensions,


### PR DESCRIPTION
After updating Agave to Yucca 0.2.1 i noticed a few things I think we can do better. This PR proposes these changes:

1. Provide the config instead of the individual data items of the configs to each config getter function. This creates a cleaner API and should not reduce customisability.
2. Align naming such that each getter is `get_xxx_config` which returns an instance of an object of type `XxxConfig` named `xxx_config`.
3. Make `train_data_dir` a required argument for the YuccaDataModule, since the current default value of `None` makes the object throw a runtime error on instantiation.

Let me know what you think!