### PR TITLE
Introduce optional concept of "experiment" and ensure wandb run is resumed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yucca"
-version = "0.2.10"
+version = "0.2.11"
 authors = [
   { name="Sebastian Llambias", email="llambias@live.dk" },
   { name="Asbjørn Munk", email="9844416+asbjrnmunk@users.noreply.github.com" },

--- a/yucca/network_architectures/utils/model_memory_estimation.py
+++ b/yucca/network_architectures/utils/model_memory_estimation.py
@@ -216,7 +216,7 @@ def find_optimal_tensor_dims(
             "Will attempt to run with supplied parameters, but this might cause issues."
         )
         print(
-            f"Estimated GPU memory usage for parameters is: {est}GB and the max vram chosen is: {max_memory_usage_in_gb-offset}GB. \n"
+            f"Estimated GPU memory usage for parameters is: {est}GB and the max requested vram is: {max_memory_usage_in_gb-offset}GB. \n"
             f"This includes an offset of {offset}GB to account for vram used by PyTorch and CUDA. \n"
             "Consider increasing the max vram or working with a smaller batch and/or patch size."
             "\n"

--- a/yucca/run/run_training.py
+++ b/yucca/run/run_training.py
@@ -79,6 +79,12 @@ def main():
         default=False,
     )
 
+    parser.add_argument(
+        "--experiment",
+        help="A name for the experiment being performed, wiht no spaces.",
+        default="default",
+    )
+
     args = parser.parse_args()
 
     task = maybe_get_task_from_task_id(args.task)
@@ -94,6 +100,7 @@ def main():
     new_version = args.new_version
     planner = args.pl
     profile = args.profile
+    experiment = args.experiment
 
     # checkpoint = args.chk
     kwargs = {}
@@ -133,6 +140,7 @@ def main():
         profile=profile,
         step_logging=False,
         task=task,
+        experiment=experiment,
         **kwargs,
     )
     manager.run_training()

--- a/yucca/training/configuration/configure_callbacks.py
+++ b/yucca/training/configuration/configure_callbacks.py
@@ -113,7 +113,7 @@ def get_loggers(
                 notes=run_description,
                 save_dir=version_dir,
                 project=project,
-                group=experiment or task,
+                group=experiment if experiment != "default" else task,
                 log_model=log_model,
                 version=ckpt_wandb_id if use_ckpt_id else None,
                 resume="must" if use_ckpt_id else None,

--- a/yucca/training/configuration/configure_callbacks.py
+++ b/yucca/training/configuration/configure_callbacks.py
@@ -113,6 +113,7 @@ def get_loggers(
                 group=task,
                 log_model=log_model,
                 version=ckpt_wandb_id if use_ckpt_id else None,
+                resume="must" if use_ckpt_id else None,
             )
         )
 

--- a/yucca/training/configuration/configure_callbacks.py
+++ b/yucca/training/configuration/configure_callbacks.py
@@ -113,7 +113,7 @@ def get_loggers(
                 notes=run_description,
                 save_dir=version_dir,
                 project=project,
-                group=experiment if experiment != "default" else task,
+                group=experiment,
                 log_model=log_model,
                 version=ckpt_wandb_id if use_ckpt_id else None,
                 resume="must" if use_ckpt_id else None,

--- a/yucca/training/configuration/configure_callbacks.py
+++ b/yucca/training/configuration/configure_callbacks.py
@@ -42,6 +42,7 @@ def get_callback_config(
     write_predictions: bool = True,
     run_name: str = None,
     run_description: str = None,
+    experiment: str = None,
 ):
     callbacks = get_callbacks(
         interval_ckpt_epochs,
@@ -66,6 +67,7 @@ def get_callback_config(
         log_model=log_model,
         run_name=run_name,
         run_description=run_description,
+        experiment=experiment,
     )
     wandb_id = get_wandb_id(loggers, enable_logging)
     profiler = get_profiler(profile, save_dir)
@@ -87,6 +89,7 @@ def get_loggers(
     version: Union[int, str],
     run_name: str,
     run_description: str,
+    experiment: str,
 ):
     # The YuccaLogger is the barebones logger needed to save hparams.yaml
     # It should generally never be disabled.
@@ -110,18 +113,12 @@ def get_loggers(
                 notes=run_description,
                 save_dir=version_dir,
                 project=project,
-                group=task,
+                group=experiment or task,
                 log_model=log_model,
                 version=ckpt_wandb_id if use_ckpt_id else None,
                 resume="must" if use_ckpt_id else None,
             )
         )
-
-        print("WANDB DEBUG INFO:")
-        print("Shoud resume", use_ckpt_id)
-        print("ckpt_wandb_id", ckpt_wandb_id)
-        print("ckpt_version_dir", ckpt_version_dir)
-        print("version_dir", version_dir)
 
     return loggers
 

--- a/yucca/training/configuration/configure_callbacks.py
+++ b/yucca/training/configuration/configure_callbacks.py
@@ -117,6 +117,12 @@ def get_loggers(
             )
         )
 
+        print("WANDB DEBUG INFO:")
+        print("Shoud resume", use_ckpt_id)
+        print("ckpt_wandb_id", ckpt_wandb_id)
+        print("ckpt_version_dir", ckpt_version_dir)
+        print("version_dir", version_dir)
+
     return loggers
 
 
@@ -181,5 +187,4 @@ def should_use_ckpt_wandb_id(ckpt_version_dir, ckpt_wandb_id, version_dir):
     # If it exists and our current output directory INCLUDING THE CURRENT VERSION is equal
     # to the previous output directory we can safely assume we're continuing an
     # interrupted run.
-    if ckpt_version_dir == version_dir:
-        return True
+    return ckpt_version_dir == version_dir

--- a/yucca/training/configuration/configure_checkpoint.py
+++ b/yucca/training/configuration/configure_checkpoint.py
@@ -7,6 +7,7 @@ from yucca.paths import yucca_models, yucca_preprocessed_data
 from yucca.preprocessing.UnsupervisedPreprocessor import UnsupervisedPreprocessor
 from yucca.preprocessing.ClassificationPreprocessor import ClassificationPreprocessor
 from yucca.training.configuration.configure_paths import PathConfig
+from yucca.utils.dict import without_keys
 from yucca.utils.files_and_folders import recursive_find_python_class
 
 
@@ -42,14 +43,15 @@ class CkptConfig:
     ckpt_version_dir: Union[str, None]
     ckpt_wandb_id: Union[str, None]
 
-    def lm_hparams(self):
-        return {
+    def lm_hparams(self, without: [] = []):
+        hparams = {
             "ckpt_path": self.ckpt_path,
             "ckpt_seed": self.ckpt_seed,
             "ckpt_plans": self.ckpt_plans,
             "ckpt_version_dir": self.ckpt_version_dir,
             "ckpt_wandb_id": self.ckpt_wandb_id,
         }
+        return without_keys(hparams, without)
 
 
 def get_checkpoint_config(path_config: PathConfig, continue_from_most_recent: bool, ckpt_path: Union[str, None] = None):

--- a/yucca/training/configuration/configure_paths.py
+++ b/yucca/training/configuration/configure_paths.py
@@ -77,11 +77,9 @@ def setup_paths_and_version(
         task,
         model_name + "__" + model_dimensions,
         manager_name + "__" + planner,
+        experiment,
         f"fold_{split_idx}",
     )
-
-    if experiment is not None:
-        save_dir = join(save_dir, experiment)
 
     version = detect_version(save_dir, continue_from_most_recent)
     version_dir = join(save_dir, f"version_{version}")

--- a/yucca/training/configuration/configure_paths.py
+++ b/yucca/training/configuration/configure_paths.py
@@ -35,6 +35,7 @@ def get_path_config(task_config: TaskConfig):
         task_config.split_idx,
         task_config.task,
         task_config.planner_name,
+        task_config.experiment,
     )
 
     return PathConfig(
@@ -67,7 +68,9 @@ def detect_version(save_dir, continue_from_most_recent) -> Union[None, int]:
             return newest_version + 1
 
 
-def setup_paths_and_version(continue_from_most_recent, manager_name, model_dimensions, model_name, split_idx, task, planner):
+def setup_paths_and_version(
+    continue_from_most_recent, manager_name, model_dimensions, model_name, split_idx, task, planner, experiment
+):
     train_data_dir = join(yucca_preprocessed_data, task, planner)
     save_dir = join(
         yucca_models,
@@ -76,6 +79,10 @@ def setup_paths_and_version(continue_from_most_recent, manager_name, model_dimen
         manager_name + "__" + planner,
         f"fold_{split_idx}",
     )
+
+    if experiment is not None:
+        save_dir = join(save_dir, experiment)
+
     version = detect_version(save_dir, continue_from_most_recent)
     version_dir = join(save_dir, f"version_{version}")
     maybe_mkdir_p(version_dir)

--- a/yucca/training/configuration/configure_plans.py
+++ b/yucca/training/configuration/configure_plans.py
@@ -7,6 +7,7 @@ from yucca.paths import yucca_models, yucca_preprocessed_data
 from yucca.preprocessing.UnsupervisedPreprocessor import UnsupervisedPreprocessor
 from yucca.preprocessing.ClassificationPreprocessor import ClassificationPreprocessor
 from yucca.training.configuration.configure_paths import PathConfig
+from yucca.utils.dict import without_keys
 from yucca.utils.files_and_folders import recursive_find_python_class
 
 
@@ -17,13 +18,14 @@ class PlanConfig:
     plans: dict
     task_type: str
 
-    def lm_hparams(self):
-        return {
+    def lm_hparams(self, without: [] = []):
+        hparams = {
             "image_extension": self.image_extension,
             "num_classes": self.num_classes,
             "plans": self.plans,
             "task_type": self.task_type,
         }
+        return without_keys(hparams, without)
 
 
 def get_plan_config(

--- a/yucca/training/configuration/configure_task.py
+++ b/yucca/training/configuration/configure_task.py
@@ -10,6 +10,7 @@ class TaskConfig:
     planner_name: str
     split_idx: int
     task: str
+    experiment: str
 
     def lm_hparams(self):
         return {
@@ -20,6 +21,7 @@ class TaskConfig:
             "planner_name": self.planner_name,
             "task": self.task,
             "split_idx": self.split_idx,
+            "experiment": self.experiment,
         }
 
 
@@ -31,6 +33,7 @@ def get_task_config(
     model_name: str = "UNet",
     planner_name: str = "YuccaPlanner",
     split_idx: int = 0,
+    experiment: str = None,
 ):
     assert model_dimensions is not None
 
@@ -42,4 +45,5 @@ def get_task_config(
         planner_name=planner_name,
         split_idx=split_idx,
         task=task,
+        experiment=experiment,
     )

--- a/yucca/training/configuration/configure_task.py
+++ b/yucca/training/configuration/configure_task.py
@@ -33,7 +33,7 @@ def get_task_config(
     model_name: str = "UNet",
     planner_name: str = "YuccaPlanner",
     split_idx: int = 0,
-    experiment: str = None,
+    experiment: str = "default",
 ):
     assert model_dimensions is not None
 

--- a/yucca/training/managers/YuccaManager.py
+++ b/yucca/training/managers/YuccaManager.py
@@ -62,6 +62,7 @@ class YuccaManager:
         split_idx: int = 0,
         step_logging: bool = False,
         task: str = None,
+        experiment: str = "default",
         train_batches_per_step: int = 250,
         val_batches_per_step: int = 50,
         **kwargs,
@@ -83,6 +84,7 @@ class YuccaManager:
         self.split_idx = split_idx
         self.step_logging = step_logging
         self.task = task
+        self.experiment = experiment
         self.train_batches_per_step = train_batches_per_step
         self.val_batches_per_step = val_batches_per_step
         self.kwargs = kwargs
@@ -112,6 +114,7 @@ class YuccaManager:
             planner_name=self.planner,
             split_idx=self.split_idx,
             task=self.task,
+            experiment=self.experiment,
         )
 
         path_config = get_path_config(task_config=task_config)

--- a/yucca/utils/dict.py
+++ b/yucca/utils/dict.py
@@ -1,0 +1,4 @@
+def without_keys(dict: {}, keys: []) -> {}:
+    if keys == [] or keys is None:
+        return dict
+    return {k: v for k, v in dict.items() if k not in keys}


### PR DESCRIPTION
I am running many different experiments and have experienced the following problems:

1. Each experiment is just called `version_x` in wandb and on disk and it is pretty much impossible to keep track of which version was which experiment. 
2. I train many models at once and need to be able to restart any of them if they crash/run out of time etc.
3. Sometimes I have to stop a run and restart from scratch because I made a stupid mistake and I want to keep track of which version was the most recent in a given experiment.
4. I am not using the Manager infrastructure but have rolled my own setup based on bash and argparse to control the experiments. It is pretty neat! You can have a look at Agave's [run.bash](https://github.com/asbjrnmunk/agave/blob/main/run.bash), [experiments](https://github.com/asbjrnmunk/agave/tree/main/experiments) and [configs](https://github.com/asbjrnmunk/agave/tree/main/configs), where the latter allows me to make configurations for both gbar (dtu cluster) and hendrix. The script can then be used like this:

![Screenshot 2023-12-29 at 14 23 33](https://github.com/Sllambias/yucca/assets/9844416/ea611df3-8784-49e6-b506-30edf0a8622d)


5. For each experiment I need to be able to log both a pre-training run _and_ fine-tuning runs in wandb and have a neat way of keeping track of these.

This PR thus proposes the following changes:

1. Change save dir to contain an optional subfolder named after the experiment inside the `fold_x` folder. In this way each experiment is one configuration of the model, while the `experiment` folder still contains versions. This allows us to keep track of different versions of each experiment separately.
2. One can easily resume the most recent version of any experiment since the `save_dir` folder is now unique per experiment.
3. Fixes wandb to have `resume="must"` when we are resuming a run.
4. If the experiment is given, wandb is grouped by experiment instead of task.
5. My wandb is loading extremely slowly, to the point where it is not really usable, because the plan is _huge_ for my dataset and javascript just sucks balls for rendering large json objects. It seems a bit wasteful to send it for each job when it doesn't change and the path to the plan is logged in the checkpoint, so I have added an optional `without` keyword in the `lm_hparams` of the relevant configs allowing one to filter out the plans or other data. It seems this might break prediction, but this is not relevant for pretrained models afaik. In agave I then do:
```python
      config=
        ....
        | ckpt_config.lm_hparams(without=["ckpt_plans"])
        ...
        | plan_config.lm_hparams(without=["plans"])
        ...
```