### PR TITLE
Fix weight transfer tl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yucca"
-version = "0.2.10"
+version = "0.2.11"
 authors = [
   { name="Sebastian Llambias", email="llambias@live.dk" },
   { name="Asbjørn Munk", email="9844416+asbjrnmunk@users.noreply.github.com" },

--- a/yucca/documentation/tests/networks/transfer_weights.ipynb
+++ b/yucca/documentation/tests/networks/transfer_weights.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from yucca.network_architectures.networks.UNet import UNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the two networks.\n",
+    "net1 = UNet(1, 3)\n",
+    "net2 = UNet(1, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[[ 0.0031,  0.1436,  0.1569],\n",
+      "         [ 0.2313, -0.2296,  0.1009],\n",
+      "         [ 0.0231,  0.1453, -0.1971]]], grad_fn=<SelectBackward0>)\n",
+      "tensor([[[ 0.1108, -0.2359,  0.2191],\n",
+      "         [ 0.2806, -0.2911,  0.1257],\n",
+      "         [-0.1171, -0.1688,  0.1678]]], grad_fn=<SelectBackward0>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get values from the start of the encoder. These will be different now, but SHOULD be equal in the end.\n",
+    "print(net1.in_conv.conv1.conv.weight[32])\n",
+    "print(net2.in_conv.conv1.conv.weight[32])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[-0.0680]], grad_fn=<SelectBackward0>)\n",
+      "tensor([[0.0780]], grad_fn=<SelectBackward0>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get values from the output conv. These will be different now, and SHOULD still be different in the end.\n",
+    "print(net1.out_conv.weight[0][0])\n",
+    "print(net2.out_conv.weight[0][0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net2.load_state_dict(net1.state_dict(), strict=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[[ 0.0031,  0.1436,  0.1569],\n",
+      "         [ 0.2313, -0.2296,  0.1009],\n",
+      "         [ 0.0231,  0.1453, -0.1971]]], grad_fn=<SelectBackward0>)\n",
+      "tensor([[[ 0.0031,  0.1436,  0.1569],\n",
+      "         [ 0.2313, -0.2296,  0.1009],\n",
+      "         [ 0.0231,  0.1453, -0.1971]]], grad_fn=<SelectBackward0>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get values from the start of the encoder again. Should be equal now.\n",
+    "print(net1.in_conv.conv1.conv.weight[32])\n",
+    "print(net2.in_conv.conv1.conv.weight[32])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[-0.0680]], grad_fn=<SelectBackward0>)\n",
+      "tensor([[0.0780]], grad_fn=<SelectBackward0>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get values from the output conv. These should be different since we're using different n_classes.\n",
+    "print(net1.out_conv.weight[0][0])\n",
+    "print(net2.out_conv.weight[0][0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "yucca2",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/yucca/network_architectures/networks/UNet.py
+++ b/yucca/network_architectures/networks/UNet.py
@@ -132,8 +132,6 @@ class UNet(YuccaNet):
             old_dropout_p = self.dropout_op_kwargs["p"]
             self.dropout_op_kwargs["p"] = 0.0
 
-        self.ds_out_conv0 = self.conv_op(self.filters * 16, self.num_classes, kernel_size=1)
-
         self.upsample1 = self.upsample(self.filters * 16, self.filters * 8, kernel_size=2, stride=2)
         self.decoder_conv1 = self.basic_block(
             self.filters * 16,
@@ -147,7 +145,6 @@ class UNet(YuccaNet):
             self.nonlin,
             self.nonlin_kwargs,
         )
-        self.ds_out_conv1 = self.conv_op(self.filters * 8, self.num_classes, kernel_size=1)
 
         self.upsample2 = self.upsample(self.filters * 8, self.filters * 4, kernel_size=2, stride=2)
         self.decoder_conv2 = self.basic_block(
@@ -162,7 +159,6 @@ class UNet(YuccaNet):
             self.nonlin,
             self.nonlin_kwargs,
         )
-        self.ds_out_conv2 = self.conv_op(self.filters * 4, self.num_classes, kernel_size=1)
 
         self.upsample3 = self.upsample(self.filters * 4, self.filters * 2, kernel_size=2, stride=2)
         self.decoder_conv3 = self.basic_block(
@@ -177,7 +173,6 @@ class UNet(YuccaNet):
             self.nonlin,
             self.nonlin_kwargs,
         )
-        self.ds_out_conv3 = self.conv_op(self.filters * 2, self.num_classes, kernel_size=1)
 
         self.upsample4 = self.upsample(self.filters * 2, self.filters, kernel_size=2, stride=2)
         self.decoder_conv4 = self.basic_block(
@@ -194,6 +189,12 @@ class UNet(YuccaNet):
         )
 
         self.out_conv = self.conv_op(self.filters, self.num_classes, kernel_size=1)
+
+        if self.deep_supervision:
+            self.ds_out_conv0 = self.conv_op(self.filters * 16, self.num_classes, kernel_size=1)
+            self.ds_out_conv1 = self.conv_op(self.filters * 8, self.num_classes, kernel_size=1)
+            self.ds_out_conv2 = self.conv_op(self.filters * 4, self.num_classes, kernel_size=1)
+            self.ds_out_conv3 = self.conv_op(self.filters * 2, self.num_classes, kernel_size=1)
 
         if not dropout_in_decoder:
             self.dropout_op_kwargs["p"] = old_dropout_p

--- a/yucca/network_architectures/networks/YuccaNet.py
+++ b/yucca/network_architectures/networks/YuccaNet.py
@@ -20,6 +20,16 @@ class YuccaNet(nn.Module):
         """
         pass
 
+    def load_state_dict(self, target_state_dict, *args, **kwargs):
+        current_state_dict = self.state_dict()
+        # filter unnecessary keys
+        target_state_dict = {
+            k: v
+            for k, v in target_state_dict.items()
+            if (k in current_state_dict) and (current_state_dict[k].shape == target_state_dict[k].shape)
+        }
+        super().load_state_dict(target_state_dict, *args, **kwargs)
+
     def predict(self, mode, data, patch_size, overlap, mirror=False):
         if torch.cuda.is_available():
             data = data.to("cuda")

--- a/yucca/run/run_finetune.py
+++ b/yucca/run/run_finetune.py
@@ -97,14 +97,15 @@ def main():
     loss = args.loss
     momentum = args.mom
     new_version = args.new_version
+    patch_size = args.patch_size
     planner = args.pl
     profile = args.profile
 
-    if args.patch_size is not None:
-        if args.patch_size in ["mean", "max", "min"]:
-            patch_size = args.patch_size
+    if patch_size is not None:
+        if patch_size in ["mean", "max", "min"]:
+            patch_size = patch_size
         else:
-            patch_size = (int(args.patch_size),) * 3 if dimensions == "3D" else (int(args.patch_size),) * 2
+            patch_size = (int(patch_size),) * 3 if dimensions == "3D" else (int(patch_size),) * 2
 
     kwargs = {}
 

--- a/yucca/training/lightning_modules/YuccaLightningModule.py
+++ b/yucca/training/lightning_modules/YuccaLightningModule.py
@@ -211,13 +211,13 @@ class YuccaLightningModule(L.LightningModule):
         # Finally return the optimizer and scheduler - the loss is not returned.
         return {"optimizer": self.optim, "lr_scheduler": self.lr_scheduler}
 
-    def load_state_dict(self, *args, **kwargs):
+    def load_state_dict(self, state_dict, *args, **kwargs):
         # Here there's also potential to implement custom loading functions.
         # E.g. to load 2D pretrained models into 3D by repeating or something like that.
         successful = 0
         unsuccessful = 0
         old_params = copy.deepcopy(self.model.state_dict())
-        super().load_state_dict(*args, **kwargs)
+        super().load_state_dict(state_dict, *args, **kwargs)
         new_params = self.model.state_dict()
         for p1, p2 in zip(old_params.values(), new_params.values()):
             # If more than one param in layer is NE (not equal) to the original weights we've successfully loaded new weights.

--- a/yucca/training/managers/YuccaManager.py
+++ b/yucca/training/managers/YuccaManager.py
@@ -215,7 +215,7 @@ class YuccaManager:
     def run_finetuning(self):
         self.initialize(stage="fit")
         self.model_module.load_state_dict(
-            torch.load(self.ckpt_config.ckpt_path, map_location=torch.device("cpu"))["state_dict"], strict=False
+            state_dict=torch.load(self.ckpt_config.ckpt_path, map_location=torch.device("cpu"))["state_dict"], strict=False
         )
         self.trainer.fit(
             model=self.model_module,


### PR DESCRIPTION
You'll like this @asbjrnmunk.
Now you can just use the U-Net for everything when you're pretraining and finetuning. I've implemented a filter to sort keys that have changed in shape (i.e. the output layer) without relying on variable names.

It's also implemented in the YuccaNet in case it's used outside the LightningModule