### PR TITLE
Improve how we use workers

### DIFF
--- a/yucca/__init__.py
+++ b/yucca/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.getLogger().setLevel(logging.INFO)

--- a/yucca/__init__.py
+++ b/yucca/__init__.py
@@ -1,3 +1,0 @@
-import os
-
-os.environ["OMP_NUM_THREADS"] = "1"

--- a/yucca/documentation/training_times.md
+++ b/yucca/documentation/training_times.md
@@ -6,3 +6,5 @@
 |   A100 80GB  |   6/24         |      160      |    06     |  Default 3D |  [128, 128, 128]  |
 |   A100 80GB  |   48/48        |      89       |    06     |  Default 3D |  [128, 128, 128]  | # First epoch ~400 seconds to start all these workers
 |   A100 80GB  |   96/96        |      87       |    06     |  Default 3D |  [128, 128, 128]  | # First epoch ~400 seconds to start all these workers
+|   A100 80GB  |   23/24        |      93       |    01     |  Default 3D |  [128, 128, 128]  |
+|   A100 80GB  |   23/24        |      94       |    01     |  Default 3D |  [128, 128, 128]  | # Tested torch.set_float32_matmul_precision('medium') 

--- a/yucca/documentation/training_times.md
+++ b/yucca/documentation/training_times.md
@@ -1,0 +1,7 @@
+|      GPU     |  CPUS/WORKERS  | SECONDS/EPOCH |    TASK   |    SETUP    |     Patch Size    |
+|              |                |               |           |             |                   | # Leave this line empty as a copy-pasta template
+|   A100 80GB  |   24/24        |      97       |    06     |  Default 3D |  [128, 128, 128]  |
+|   A100 80GB  |   20/24        |      97       |    06     |  Default 3D |  [128, 128, 128]  |
+|   A100 80GB  |   12/24        |      110      |    06     |  Default 3D |  [128, 128, 128]  |
+|   A100 80GB  |   6/24         |      160      |    06     |  Default 3D |  [128, 128, 128]  |
+|   A100 80GB  |   48/48        |      89       |    06     |  Default 3D |  [128, 128, 128]  | # First epoch ~400 seconds to start all these workers

--- a/yucca/documentation/training_times.md
+++ b/yucca/documentation/training_times.md
@@ -5,3 +5,4 @@
 |   A100 80GB  |   12/24        |      110      |    06     |  Default 3D |  [128, 128, 128]  |
 |   A100 80GB  |   6/24         |      160      |    06     |  Default 3D |  [128, 128, 128]  |
 |   A100 80GB  |   48/48        |      89       |    06     |  Default 3D |  [128, 128, 128]  | # First epoch ~400 seconds to start all these workers
+|   A100 80GB  |   96/96        |      87       |    06     |  Default 3D |  [128, 128, 128]  | # First epoch ~400 seconds to start all these workers

--- a/yucca/run/run_finetune.py
+++ b/yucca/run/run_finetune.py
@@ -92,6 +92,13 @@ def main():
     )
     parser.add_argument("-f", "--split_idx", type=int, help="idx of splits to use for training.", default=0)
 
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        help="Num workers used in the DataLoaders. By default this will be inferred from the number of available CPUs-1",
+        default=None,
+    )
+
     args = parser.parse_args()
 
     task = maybe_get_task_from_task_id(args.task)
@@ -109,6 +116,7 @@ def main():
     planner = args.pl
     profile = args.profile
 
+    num_workers = args.num_workers
     split_idx = args.split_idx
     split_data_ratio = args.split_data_ratio
     split_data_kfold = args.split_data_kfold
@@ -155,7 +163,7 @@ def main():
         model_dimensions=dimensions,
         model_name=model_name,
         momentum=momentum,
-        num_workers=8,
+        num_workers=num_workers,
         patch_size=patch_size,
         planner=planner,
         precision=args.precision,

--- a/yucca/run/run_training.py
+++ b/yucca/run/run_training.py
@@ -1,6 +1,5 @@
 import argparse
 import yucca
-import torch
 from yucca.utils.task_ids import maybe_get_task_from_task_id
 from yucca.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join

--- a/yucca/run/run_training.py
+++ b/yucca/run/run_training.py
@@ -1,5 +1,6 @@
 import argparse
 import yucca
+import torch
 from yucca.utils.task_ids import maybe_get_task_from_task_id
 from yucca.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join
@@ -173,7 +174,7 @@ def main():
         model_dimensions=dimensions,
         model_name=model_name,
         momentum=momentum,
-        num_workers=8,
+        num_workers=max(0, int(torch.get_num_threads())),
         planner=planner,
         precision=args.precision,
         profile=profile,

--- a/yucca/run/run_training.py
+++ b/yucca/run/run_training.py
@@ -104,6 +104,13 @@ def main():
     parser.add_argument("--train_batches_per_step", type=int, default=250)
     parser.add_argument("--val_batches_per_step", type=int, default=50)
 
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        help="Num workers used in the DataLoaders. By default this will be inferred from the number of available CPUs-1",
+        default=None,
+    )
+
     args = parser.parse_args()
 
     task = maybe_get_task_from_task_id(args.task)
@@ -125,6 +132,8 @@ def main():
     split_idx = args.split_idx
     split_data_ratio = args.split_data_ratio
     split_data_kfold = args.split_data_kfold
+
+    num_workers = args.num_workers
 
     if split_data_kfold is None and split_data_ratio is None:
         split_data_kfold = 5
@@ -174,7 +183,7 @@ def main():
         model_dimensions=dimensions,
         model_name=model_name,
         momentum=momentum,
-        num_workers=max(0, int(torch.get_num_threads())),
+        num_workers=num_workers,
         planner=planner,
         precision=args.precision,
         profile=profile,

--- a/yucca/training/__init__.py
+++ b/yucca/training/__init__.py
@@ -1,3 +1,0 @@
-import os
-
-os.environ["OMP_NUM_THREADS"] = "1"

--- a/yucca/training/data_loading/YuccaDataModule.py
+++ b/yucca/training/data_loading/YuccaDataModule.py
@@ -1,5 +1,6 @@
 import lightning as pl
 import torchvision
+import torch
 from typing import Literal, Optional
 from torch.utils.data import DataLoader, Sampler
 from batchgenerators.utilities.file_and_folder_operations import join
@@ -123,7 +124,7 @@ class YuccaDataModule(pl.LightningDataModule):
             self.train_dataset,
             num_workers=self.num_workers,
             batch_size=self.batch_size,
-            persistent_workers=bool(self.num_workers),
+            pin_memory=torch.cuda.is_available(),
             sampler=sampler,
             shuffle=sampler is None,
         )
@@ -134,7 +135,7 @@ class YuccaDataModule(pl.LightningDataModule):
             self.val_dataset,
             num_workers=self.val_num_workers,
             batch_size=self.batch_size,
-            persistent_workers=bool(self.val_num_workers),
+            pin_memory=torch.cuda.is_available(),
             sampler=sampler,
         )
 

--- a/yucca/training/managers/YuccaManager.py
+++ b/yucca/training/managers/YuccaManager.py
@@ -1,6 +1,6 @@
 import lightning as L
 import torch
-from typing import Literal, Union
+from typing import Literal, Union, Optional
 from yucca.training.augmentation.YuccaAugmentationComposer import YuccaAugmentationComposer
 from yucca.training.configuration.split_data import get_split_config, SplitConfig
 from yucca.training.configuration.configure_task import get_task_config
@@ -56,7 +56,7 @@ class YuccaManager:
         model_dimensions: str = "3D",
         model_name: str = "TinyUNet",
         momentum: float = 0.9,
-        num_workers: int = 8,
+        num_workers: Optional[int] = None,
         patch_based_training: bool = True,
         patch_size: Union[tuple, Literal["max", "min", "mean"]] = None,
         augmentation_params: dict = {},


### PR DESCRIPTION
Remove persistent workers and OMP limit on number of threads per process

Instead, Pin memory and allow more workers.

- [x] IMPLEMENTED: Make sure we implement consistent default n worker selection across all scripts (maybe do it in the manager?)
- [x] NOT IMPLEMENTED: MADE NO DIFFERENCE: Try "You are using a CUDA device ('NVIDIA A100 80GB PCIe') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision"