### PR TITLE
Get paths using functions, not global variables and fix local prediction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yucca"
-version = "1.1.6.1"
+version = "1.1.6.2"
 authors = [
   { name="Sebastian Llambias", email="llambias@live.com" },
   { name="Asbjørn Munk", email="9844416+asbjrnmunk@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yucca"
-version = "1.1.6.2"
+version = "1.1.7"
 authors = [
   { name="Sebastian Llambias", email="llambias@live.com" },
   { name="Asbjørn Munk", email="9844416+asbjrnmunk@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yucca"
-version = "1.1.6"
+version = "1.1.6.1"
 authors = [
   { name="Sebastian Llambias", email="llambias@live.com" },
   { name="Asbjørn Munk", email="9844416+asbjrnmunk@users.noreply.github.com" },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,14 +40,14 @@ def set_env():
 
 @pytest.fixture
 def setup_preprocessed_segmentation_data(request):
-    from yucca.paths import yucca_raw_data, yucca_preprocessed_data
+    from yucca.paths import get_yucca_raw_data, get_yucca_preprocessed_data
 
     subprocess.run(["yucca_convert_task", "-t", "Task000_TEST_SEGMENTATION"], check=True)
     subprocess.run(["yucca_preprocess", "-t", "Task000_TEST_SEGMENTATION"], check=True)
 
     def finalizer():
-        shutil.rmtree(yucca_raw_data())
-        shutil.rmtree(yucca_preprocessed_data())
+        shutil.rmtree(get_yucca_raw_data())
+        shutil.rmtree(get_yucca_preprocessed_data())
 
     request.addfinalizer(finalizer)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,14 +40,14 @@ def set_env():
 
 @pytest.fixture
 def setup_preprocessed_segmentation_data(request):
-    from yucca.paths import get_yucca_raw_data, get_yucca_preprocessed_data
+    from yucca.paths import get_raw_data_path, get_preprocessed_data_path
 
     subprocess.run(["yucca_convert_task", "-t", "Task000_TEST_SEGMENTATION"], check=True)
     subprocess.run(["yucca_preprocess", "-t", "Task000_TEST_SEGMENTATION"], check=True)
 
     def finalizer():
-        shutil.rmtree(get_yucca_raw_data())
-        shutil.rmtree(get_yucca_preprocessed_data())
+        shutil.rmtree(get_raw_data_path())
+        shutil.rmtree(get_preprocessed_data_path())
 
     request.addfinalizer(finalizer)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,8 @@ def setup_preprocessed_segmentation_data(request):
     subprocess.run(["yucca_preprocess", "-t", "Task000_TEST_SEGMENTATION"], check=True)
 
     def finalizer():
-        shutil.rmtree(yucca_raw_data)
-        shutil.rmtree(yucca_preprocessed_data)
+        shutil.rmtree(yucca_raw_data())
+        shutil.rmtree(yucca_preprocessed_data())
 
     request.addfinalizer(finalizer)
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -74,10 +74,10 @@ def test_training():
 
 
 def test_finetune():
-    from yucca.paths import get_yucca_models
+    from yucca.paths import get_models_path
 
     chk = os.path.join(
-        get_yucca_models(),
+        get_models_path(),
         "Task000_TEST_SEGMENTATION",
         "TinyUNet__3D",
         "YuccaManager__YuccaPlanner",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -77,7 +77,7 @@ def test_finetune():
     from yucca.paths import yucca_models
 
     chk = os.path.join(
-        yucca_models,
+        yucca_models(),
         "Task000_TEST_SEGMENTATION",
         "TinyUNet__3D",
         "YuccaManager__YuccaPlanner",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -74,10 +74,10 @@ def test_training():
 
 
 def test_finetune():
-    from yucca.paths import yucca_models
+    from yucca.paths import get_yucca_models
 
     chk = os.path.join(
-        yucca_models(),
+        get_yucca_models(),
         "Task000_TEST_SEGMENTATION",
         "TinyUNet__3D",
         "YuccaManager__YuccaPlanner",

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,4 @@
 def test_loads_env_var():
-    from yucca.paths import yucca_raw_data
+    from yucca.paths import get_yucca_raw_data
 
-    assert yucca_raw_data() is not None
+    assert get_yucca_raw_data() is not None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,4 @@
 def test_loads_env_var():
     from yucca.paths import yucca_raw_data
 
-    assert yucca_raw_data is not None
+    assert yucca_raw_data(),  is not None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,4 @@
 def test_loads_env_var():
-    from yucca.paths import get_yucca_raw_data
+    from yucca.paths import get_raw_data_path
 
-    assert get_yucca_raw_data() is not None
+    assert get_raw_data_path() is not None

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,4 @@
 def test_loads_env_var():
     from yucca.paths import yucca_raw_data
 
-    assert yucca_raw_data(),  is not None
+    assert yucca_raw_data() is not None

--- a/yucca/documentation/guides/environment_variables.md
+++ b/yucca/documentation/guides/environment_variables.md
@@ -3,7 +3,7 @@ What's the purpose of this?
 
 To the maximum extent possible we don't want hardcoded paths. It is simply bad practice and completely lacks scalability. Using environment variables allows us to limit hardcoded paths to the Task Conversion scripts.
 
-## Yucca installed locally using git clone 
+## Yucca installed locally using git clone
 To setup environment variables add the following `.env` file to the root Yucca folder:
 
 ```
@@ -20,7 +20,7 @@ As an example `<path-to-yucca-data-diretory>` could be substituted by `/data/yuc
 ## Yucca installed as a package with conda environments
 From the official conda [guide](#https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#macos-and-linux):
 
-1. Create the following directories and files 
+1. Create the following directories and files
 ```
 conda activate YOUR_YUCCA_ENV_HERE
 cd $CONDA_PREFIX
@@ -61,7 +61,7 @@ YUCCA_PREPROCESSED_DATA=<path-to-yucca-data-diretory>/preprocessed_data
 YUCCA_MODELS=<path-to-yucca-data-diretory>/models
 YUCCA_RESULTS=<path-to-yucca-data-diretory>/results
 ```
-2. 
+2.
 2a. Add the poetry dotenv plugin
 ```
 poetry self add poetry-plugin-dotenv

--- a/yucca/documentation/templates/functional_inference.py
+++ b/yucca/documentation/templates/functional_inference.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     from yucca.documentation.templates.template_config import config
 
     ckpt_path = os.path.join(
-        yucca_models,
+        yucca_models(),
         config["task"],
         config["model_name"] + "__" + config["dims"],
         "__" + config["plans_name"],
@@ -23,11 +23,11 @@ if __name__ == "__main__":
         "last.ckpt",
     )
 
-    gt_path = os.path.join(yucca_raw_data, config["task"], "labelsTs")
-    target_data_path = os.path.join(yucca_preprocessed_data, config["task"] + "_test", "demo")
+    gt_path = os.path.join(yucca_raw_data(), config["task"], "labelsTs")
+    target_data_path = os.path.join(yucca_preprocessed_data(), config["task"] + "_test", "demo")
 
     save_path = os.path.join(
-        yucca_results,
+        yucca_results(),
         config["task"],
         config["task"],
         config["model_name"] + "__" + config["dims"],

--- a/yucca/documentation/templates/functional_inference.py
+++ b/yucca/documentation/templates/functional_inference.py
@@ -3,7 +3,7 @@ if __name__ == "__main__":
     import os
     import torch
     from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p
-    from yucca.paths import yucca_models, yucca_results, yucca_preprocessed_data, yucca_raw_data
+    from yucca.paths import get_yucca_models, get_yucca_results, get_yucca_preprocessed_data, get_yucca_raw_data
     from yucca.modules.callbacks.prediction_writer import WritePredictionFromLogits
     from yucca.modules.lightning_modules.YuccaLightningModule import YuccaLightningModule
     from yucca.modules.data.data_modules.YuccaDataModule import YuccaDataModule
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     from yucca.documentation.templates.template_config import config
 
     ckpt_path = os.path.join(
-        yucca_models(),
+        get_yucca_models(),
         config["task"],
         config["model_name"] + "__" + config["dims"],
         "__" + config["plans_name"],
@@ -23,11 +23,11 @@ if __name__ == "__main__":
         "last.ckpt",
     )
 
-    gt_path = os.path.join(yucca_raw_data(), config["task"], "labelsTs")
-    target_data_path = os.path.join(yucca_preprocessed_data(), config["task"] + "_test", "demo")
+    gt_path = os.path.join(get_yucca_raw_data(), config["task"], "labelsTs")
+    target_data_path = os.path.join(get_yucca_preprocessed_data(), config["task"] + "_test", "demo")
 
     save_path = os.path.join(
-        yucca_results(),
+        get_yucca_results(),
         config["task"],
         config["task"],
         config["model_name"] + "__" + config["dims"],

--- a/yucca/documentation/templates/functional_inference.py
+++ b/yucca/documentation/templates/functional_inference.py
@@ -3,7 +3,12 @@ if __name__ == "__main__":
     import os
     import torch
     from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p
-    from yucca.paths import get_yucca_models, get_yucca_results, get_yucca_preprocessed_data, get_yucca_raw_data
+    from yucca.paths import (
+        get_models_path,
+        get_results_path,
+        get_preprocessed_data_path,
+        get_raw_data_path,
+    )
     from yucca.modules.callbacks.prediction_writer import WritePredictionFromLogits
     from yucca.modules.lightning_modules.YuccaLightningModule import YuccaLightningModule
     from yucca.modules.data.data_modules.YuccaDataModule import YuccaDataModule
@@ -12,7 +17,7 @@ if __name__ == "__main__":
     from yucca.documentation.templates.template_config import config
 
     ckpt_path = os.path.join(
-        get_yucca_models(),
+        get_models_path(),
         config["task"],
         config["model_name"] + "__" + config["dims"],
         "__" + config["plans_name"],
@@ -23,11 +28,11 @@ if __name__ == "__main__":
         "last.ckpt",
     )
 
-    gt_path = os.path.join(get_yucca_raw_data(), config["task"], "labelsTs")
-    target_data_path = os.path.join(get_yucca_preprocessed_data(), config["task"] + "_test", "demo")
+    gt_path = os.path.join(get_raw_data_path(), config["task"], "labelsTs")
+    target_data_path = os.path.join(get_preprocessed_data_path(), config["task"] + "_test", "demo")
 
     save_path = os.path.join(
-        get_yucca_results(),
+        get_results_path(),
         config["task"],
         config["task"],
         config["model_name"] + "__" + config["dims"],

--- a/yucca/documentation/templates/functional_preprocessing.py
+++ b/yucca/documentation/templates/functional_preprocessing.py
@@ -5,18 +5,18 @@ if __name__ == "__main__":
     import numpy as np
     import torch
     from batchgenerators.utilities.file_and_folder_operations import subfiles, join, save_pickle, maybe_mkdir_p, save_json
-    from yucca.paths import yucca_raw_data, yucca_preprocessed_data
+    from yucca.paths import get_yucca_raw_data, get_yucca_preprocessed_data
     from yucca.documentation.templates.template_config import config
     from yucca.functional.preprocessing import preprocess_case_for_training_with_label, preprocess_case_for_inference
     from yucca.functional.utils.loading import read_file_to_nifti_or_np
     from yucca.functional.planning import make_plans_file, add_stats_to_plans_post_preprocessing
 
-    raw_images_dir = join(yucca_raw_data(), config["task"], "imagesTr")
-    raw_labels_dir = join(yucca_raw_data(), config["task"], "labelsTr")
-    test_raw_images_dir = join(yucca_raw_data(), config["task"], "imagesTs")
+    raw_images_dir = join(get_yucca_raw_data(), config["task"], "imagesTr")
+    raw_labels_dir = join(get_yucca_raw_data(), config["task"], "labelsTr")
+    test_raw_images_dir = join(get_yucca_raw_data(), config["task"], "imagesTs")
 
-    target_dir = join(yucca_preprocessed_data(), config["task"], config["plans_name"])
-    test_target_dir = join(yucca_preprocessed_data(), config["task"] + "_test", config["plans_name"])
+    target_dir = join(get_yucca_preprocessed_data(), config["task"], config["plans_name"])
+    test_target_dir = join(get_yucca_preprocessed_data(), config["task"] + "_test", config["plans_name"])
 
     maybe_mkdir_p(target_dir)
     maybe_mkdir_p(test_target_dir)

--- a/yucca/documentation/templates/functional_preprocessing.py
+++ b/yucca/documentation/templates/functional_preprocessing.py
@@ -11,12 +11,12 @@ if __name__ == "__main__":
     from yucca.functional.utils.loading import read_file_to_nifti_or_np
     from yucca.functional.planning import make_plans_file, add_stats_to_plans_post_preprocessing
 
-    raw_images_dir = join(yucca_raw_data, config["task"], "imagesTr")
-    raw_labels_dir = join(yucca_raw_data, config["task"], "labelsTr")
-    test_raw_images_dir = join(yucca_raw_data, config["task"], "imagesTs")
+    raw_images_dir = join(yucca_raw_data(), config["task"], "imagesTr")
+    raw_labels_dir = join(yucca_raw_data(), config["task"], "labelsTr")
+    test_raw_images_dir = join(yucca_raw_data(), config["task"], "imagesTs")
 
-    target_dir = join(yucca_preprocessed_data, config["task"], config["plans_name"])
-    test_target_dir = join(yucca_preprocessed_data, config["task"] + "_test", config["plans_name"])
+    target_dir = join(yucca_preprocessed_data(), config["task"], config["plans_name"])
+    test_target_dir = join(yucca_preprocessed_data(), config["task"] + "_test", config["plans_name"])
 
     maybe_mkdir_p(target_dir)
     maybe_mkdir_p(test_target_dir)

--- a/yucca/documentation/templates/functional_preprocessing.py
+++ b/yucca/documentation/templates/functional_preprocessing.py
@@ -5,18 +5,18 @@ if __name__ == "__main__":
     import numpy as np
     import torch
     from batchgenerators.utilities.file_and_folder_operations import subfiles, join, save_pickle, maybe_mkdir_p, save_json
-    from yucca.paths import get_yucca_raw_data, get_yucca_preprocessed_data
+    from yucca.paths import get_raw_data_path, get_preprocessed_data_path
     from yucca.documentation.templates.template_config import config
     from yucca.functional.preprocessing import preprocess_case_for_training_with_label, preprocess_case_for_inference
     from yucca.functional.utils.loading import read_file_to_nifti_or_np
     from yucca.functional.planning import make_plans_file, add_stats_to_plans_post_preprocessing
 
-    raw_images_dir = join(get_yucca_raw_data(), config["task"], "imagesTr")
-    raw_labels_dir = join(get_yucca_raw_data(), config["task"], "labelsTr")
-    test_raw_images_dir = join(get_yucca_raw_data(), config["task"], "imagesTs")
+    raw_images_dir = join(get_raw_data_path(), config["task"], "imagesTr")
+    raw_labels_dir = join(get_raw_data_path(), config["task"], "labelsTr")
+    test_raw_images_dir = join(get_raw_data_path(), config["task"], "imagesTs")
 
-    target_dir = join(get_yucca_preprocessed_data(), config["task"], config["plans_name"])
-    test_target_dir = join(get_yucca_preprocessed_data(), config["task"] + "_test", config["plans_name"])
+    target_dir = join(get_preprocessed_data_path(), config["task"], config["plans_name"])
+    test_target_dir = join(get_preprocessed_data_path(), config["task"] + "_test", config["plans_name"])
 
     maybe_mkdir_p(target_dir)
     maybe_mkdir_p(test_target_dir)

--- a/yucca/documentation/templates/functional_training.py
+++ b/yucca/documentation/templates/functional_training.py
@@ -3,7 +3,7 @@ if __name__ == "__main__":
     import lightning as L
     import os
     from batchgenerators.utilities.file_and_folder_operations import load_json
-    from yucca.paths import get_yucca_preprocessed_data
+    from yucca.paths import get_preprocessed_data_path
     from yucca.pipeline.configuration.configure_task import TaskConfig
     from yucca.pipeline.configuration.configure_paths import get_path_config
     from yucca.pipeline.configuration.configure_callbacks import get_callback_config
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     from yucca.documentation.templates.template_config import config
 
     config["plans"] = load_json(
-        os.path.join(get_yucca_preprocessed_data(), config["task"], config["plans_name"], config["plans_name"] + "_plans.json")
+        os.path.join(get_preprocessed_data_path(), config["task"], config["plans_name"], config["plans_name"] + "_plans.json")
     )
 
     task_config = TaskConfig(

--- a/yucca/documentation/templates/functional_training.py
+++ b/yucca/documentation/templates/functional_training.py
@@ -3,7 +3,7 @@ if __name__ == "__main__":
     import lightning as L
     import os
     from batchgenerators.utilities.file_and_folder_operations import load_json
-    from yucca.paths import yucca_preprocessed_data
+    from yucca.paths import get_yucca_preprocessed_data
     from yucca.pipeline.configuration.configure_task import TaskConfig
     from yucca.pipeline.configuration.configure_paths import get_path_config
     from yucca.pipeline.configuration.configure_callbacks import get_callback_config
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     from yucca.documentation.templates.template_config import config
 
     config["plans"] = load_json(
-        os.path.join(yucca_preprocessed_data(), config["task"], config["plans_name"], config["plans_name"] + "_plans.json")
+        os.path.join(get_yucca_preprocessed_data(), config["task"], config["plans_name"], config["plans_name"] + "_plans.json")
     )
 
     task_config = TaskConfig(

--- a/yucca/documentation/templates/functional_training.py
+++ b/yucca/documentation/templates/functional_training.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     from yucca.documentation.templates.template_config import config
 
     config["plans"] = load_json(
-        os.path.join(yucca_preprocessed_data, config["task"], config["plans_name"], config["plans_name"] + "_plans.json")
+        os.path.join(yucca_preprocessed_data(), config["task"], config["plans_name"], config["plans_name"] + "_plans.json")
     )
 
     task_config = TaskConfig(

--- a/yucca/documentation/tests/transforms/dataloader.ipynb
+++ b/yucca/documentation/tests/transforms/dataloader.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "samples = subfiles(join(yucca_preprocessed_data, \"Task299_Combine\", \"UnsupervisedPlanner\"), suffix=\".npy\")\n",
+    "samples = subfiles(join(yucca_preprocessed_data(), \"Task299_Combine\", \"UnsupervisedPlanner\"), suffix=\".npy\")\n",
     "\n",
     "\n",
     "dataset = YuccaTrainDataset(samples=samples, patch_size=(96,) * 3, composed_transforms=None, task_type=\"contrastive\")\n",
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples = subfiles(join(yucca_preprocessed_data, \"Task001_OASIS\", \"YuccaPlanner\"), suffix=\".npy\")\n",
+    "samples = subfiles(join(yucca_preprocessed_data(), \"Task001_OASIS\", \"YuccaPlanner\"), suffix=\".npy\")\n",
     "\n",
     "print(samples)\n",
     "\n",

--- a/yucca/modules/data/datasets/YuccaDataset.py
+++ b/yucca/modules/data/datasets/YuccaDataset.py
@@ -234,11 +234,11 @@ class YuccaTestPreprocessedDataset(torch.utils.data.Dataset):
 
 if __name__ == "__main__":
     import torch
-    from yucca.paths import get_yucca_preprocessed_data
+    from yucca.paths import get_preprocessed_data_path
     from batchgenerators.utilities.file_and_folder_operations import join
     from yucca.modules.data.samplers import InfiniteRandomSampler
 
-    files = subfiles(join(get_yucca_preprocessed_data(), "Task001_OASIS/YuccaPlanner"), suffix="npy")
+    files = subfiles(join(get_preprocessed_data_path(), "Task001_OASIS/YuccaPlanner"), suffix="npy")
     ds = YuccaTrainDataset(files, patch_size=(12, 12, 12))
     sampler = InfiniteRandomSampler(ds)
     dl = torch.utils.data.DataLoader(ds, num_workers=2, batch_size=2, sampler=sampler)

--- a/yucca/modules/data/datasets/YuccaDataset.py
+++ b/yucca/modules/data/datasets/YuccaDataset.py
@@ -238,7 +238,7 @@ if __name__ == "__main__":
     from batchgenerators.utilities.file_and_folder_operations import join
     from yucca.modules.data.samplers import InfiniteRandomSampler
 
-    files = subfiles(join(yucca_preprocessed_data, "Task001_OASIS/YuccaPlanner"), suffix="npy")
+    files = subfiles(join(yucca_preprocessed_data(), "Task001_OASIS/YuccaPlanner"), suffix="npy")
     ds = YuccaTrainDataset(files, patch_size=(12, 12, 12))
     sampler = InfiniteRandomSampler(ds)
     dl = torch.utils.data.DataLoader(ds, num_workers=2, batch_size=2, sampler=sampler)

--- a/yucca/modules/data/datasets/YuccaDataset.py
+++ b/yucca/modules/data/datasets/YuccaDataset.py
@@ -234,11 +234,11 @@ class YuccaTestPreprocessedDataset(torch.utils.data.Dataset):
 
 if __name__ == "__main__":
     import torch
-    from yucca.paths import yucca_preprocessed_data
+    from yucca.paths import get_yucca_preprocessed_data
     from batchgenerators.utilities.file_and_folder_operations import join
     from yucca.modules.data.samplers import InfiniteRandomSampler
 
-    files = subfiles(join(yucca_preprocessed_data(), "Task001_OASIS/YuccaPlanner"), suffix="npy")
+    files = subfiles(join(get_yucca_preprocessed_data(), "Task001_OASIS/YuccaPlanner"), suffix="npy")
     ds = YuccaTrainDataset(files, patch_size=(12, 12, 12))
     sampler = InfiniteRandomSampler(ds)
     dl = torch.utils.data.DataLoader(ds, num_workers=2, batch_size=2, sampler=sampler)

--- a/yucca/modules/networks/networks/YuccaNet.py
+++ b/yucca/modules/networks/networks/YuccaNet.py
@@ -31,29 +31,33 @@ class YuccaNet(nn.Module):
         }
         super().load_state_dict(target_state_dict, *args, **kwargs)
 
-    def predict(self, mode, data, patch_size, overlap, sliding_window_prediction=True, mirror=False):
-        # data = data.to(torch.device(get_available_device()))
+    def predict(
+        self, mode, data, patch_size, overlap, sliding_window_prediction=True, mirror=False, device=get_available_device()
+    ):
+        data = data.to(device)
 
         if not sliding_window_prediction:
             return self._full_image_predict(data)
 
-        if mode == "3D":
-            predict = self._sliding_window_predict3D
-        elif mode == "2D":
-            predict = self._sliding_window_predict2D
+        assert mode in ["3D", "2D"]
 
-        pred = predict(data, patch_size, overlap)
+        if mode == "3D":
+            predict_fn = self._sliding_window_predict3D
+        elif mode == "2D":
+            predict_fn = self._sliding_window_predict2D
+
+        pred = predict_fn(data, patch_size, overlap, device=device)
         if mirror:
-            pred += torch.flip(predict(torch.flip(data, (2,)), patch_size, overlap), (2,))
-            pred += torch.flip(predict(torch.flip(data, (3,)), patch_size, overlap), (3,))
-            pred += torch.flip(predict(torch.flip(data, (2, 3)), patch_size, overlap), (2, 3))
+            pred += torch.flip(predict_fn(torch.flip(data, (2,)), patch_size, overlap, device=device), (2,))
+            pred += torch.flip(predict_fn(torch.flip(data, (3,)), patch_size, overlap, device=device), (3,))
+            pred += torch.flip(predict_fn(torch.flip(data, (2, 3)), patch_size, overlap, device=device), (2, 3))
             div = 4
             if mode == "3D":
-                pred += torch.flip(predict(torch.flip(data, (4,)), patch_size, overlap), (4,))
-                pred += torch.flip(predict(torch.flip(data, (2, 4)), patch_size, overlap), (2, 4))
-                pred += torch.flip(predict(torch.flip(data, (3, 4)), patch_size, overlap), (3, 4))
+                pred += torch.flip(predict_fn(torch.flip(data, (4,)), patch_size, overlap, device=device), (4,))
+                pred += torch.flip(predict_fn(torch.flip(data, (2, 4)), patch_size, overlap, device=device), (2, 4))
+                pred += torch.flip(predict_fn(torch.flip(data, (3, 4)), patch_size, overlap, device=device), (3, 4))
                 pred += torch.flip(
-                    predict(torch.flip(data, (2, 3, 4)), patch_size, overlap),
+                    predict_fn(torch.flip(data, (2, 3, 4)), patch_size, overlap, device=device),
                     (2, 3, 4),
                 )
                 div += 4
@@ -68,13 +72,13 @@ class YuccaNet(nn.Module):
         """
         return self.forward(data)
 
-    def _sliding_window_predict3D(self, data, patch_size, overlap):
+    def _sliding_window_predict3D(self, data, patch_size, overlap, device):
         """
         Sliding window prediction implementation
         """
         canvas = torch.zeros(
             (1, self.num_classes, *data.shape[2:]),
-            device=torch.device(get_available_device()),
+            device=device,
         )
 
         x_steps, y_steps, z_steps = get_steps_for_sliding_window(data.shape[2:], patch_size, overlap)
@@ -88,13 +92,13 @@ class YuccaNet(nn.Module):
                     canvas[:, :, xs : xs + px, ys : ys + py, zs : zs + pz] += out
         return canvas
 
-    def _sliding_window_predict2D(self, data, patch_size, overlap):
+    def _sliding_window_predict2D(self, data, patch_size, overlap, device):
         """
         Sliding window prediction implementation
         """
         canvas = torch.zeros(
             (1, self.num_classes, *data.shape[2:]),
-            device=torch.device(get_available_device()),
+            device=device,
         )
 
         px, py = patch_size

--- a/yucca/modules/networks/networks/YuccaNet.py
+++ b/yucca/modules/networks/networks/YuccaNet.py
@@ -32,7 +32,7 @@ class YuccaNet(nn.Module):
         super().load_state_dict(target_state_dict, *args, **kwargs)
 
     def predict(self, mode, data, patch_size, overlap, sliding_window_prediction=True, mirror=False):
-        data = data.to(torch.device(get_available_device()))
+        # data = data.to(torch.device(get_available_device()))
 
         if not sliding_window_prediction:
             return self._full_image_predict(data)

--- a/yucca/paths.py
+++ b/yucca/paths.py
@@ -3,31 +3,44 @@ PLEASE READ YUCCA/DOCUMENTATION/TUTORIALS/ENVIRONMENT_VARIABLES.MD FOR INFORMATI
 """
 
 import os
-import warnings
 from dotenv import load_dotenv
 
-from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p
+from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p as ensure_dir_exists
 
-load_dotenv()
 
-vars = ["YUCCA_SOURCE", "YUCCA_RAW_DATA", "YUCCA_PREPROCESSED_DATA", "YUCCA_MODELS", "YUCCA_RESULTS"]
-vals = {}
+def var_is_set(var):
+    return var in os.environ.keys()
 
-for var in vars:
-    if var in os.environ.keys():
-        vals[var] = os.environ[var]
-        maybe_mkdir_p(vals[var])
-    else:
-        warnings.warn(f"Missing environment variable {var}.")
-        vals[var] = None
 
-yucca_source = vals["YUCCA_SOURCE"]
-yucca_raw_data = vals["YUCCA_RAW_DATA"]
-yucca_preprocessed_data = vals["YUCCA_PREPROCESSED_DATA"]
-yucca_models = vals["YUCCA_MODELS"]
-yucca_results = vals["YUCCA_RESULTS"]
+def get_environment_variable(var):
+    load_dotenv()
+    if not var_is_set(var):
+        raise ValueError("Missing required environment variable {YUCCA_SOURCE}.")
 
-if "YUCCA_WANDB_ENTITY" in os.environ.keys():
-    yucca_wandb_entity = os.environ["YUCCA_WANDB_ENTITY"]
-else:
-    yucca_wandb_entity = None
+    path = os.environ[var]
+    ensure_dir_exists(path)
+    return path
+
+
+def yucca_source():
+    return get_environment_variable("YUCCA_SOURCE")
+
+
+def yucca_raw_data():
+    return get_environment_variable("YUCCA_RAW_DATA")
+
+
+def yucca_preprocessed_data():
+    return get_environment_variable("YUCCA_PREPROCESSED_DATA")
+
+
+def yucca_models():
+    return get_environment_variable("YUCCA_MODELS")
+
+
+def yucca_results():
+    return get_environment_variable("YUCCA_RESULTS")
+
+
+def yucca_wandb_entity():
+    return os.getenv("YUCCA_WANDB_ENTITY")

--- a/yucca/paths.py
+++ b/yucca/paths.py
@@ -22,23 +22,23 @@ def get_environment_variable(var):
     return path
 
 
-def get_yucca_source():
+def get_source_path():
     return get_environment_variable("YUCCA_SOURCE")
 
 
-def get_yucca_raw_data():
+def get_raw_data_path():
     return get_environment_variable("YUCCA_RAW_DATA")
 
 
-def get_yucca_preprocessed_data():
+def get_preprocessed_data_path():
     return get_environment_variable("YUCCA_PREPROCESSED_DATA")
 
 
-def get_yucca_models():
+def get_models_path():
     return get_environment_variable("YUCCA_MODELS")
 
 
-def get_yucca_results():
+def get_results_path():
     return get_environment_variable("YUCCA_RESULTS")
 
 

--- a/yucca/paths.py
+++ b/yucca/paths.py
@@ -22,25 +22,25 @@ def get_environment_variable(var):
     return path
 
 
-def yucca_source():
+def get_yucca_source():
     return get_environment_variable("YUCCA_SOURCE")
 
 
-def yucca_raw_data():
+def get_yucca_raw_data():
     return get_environment_variable("YUCCA_RAW_DATA")
 
 
-def yucca_preprocessed_data():
+def get_yucca_preprocessed_data():
     return get_environment_variable("YUCCA_PREPROCESSED_DATA")
 
 
-def yucca_models():
+def get_yucca_models():
     return get_environment_variable("YUCCA_MODELS")
 
 
-def yucca_results():
+def get_yucca_results():
     return get_environment_variable("YUCCA_RESULTS")
 
 
-def yucca_wandb_entity():
+def get_yucca_wandb_entity():
     return os.getenv("YUCCA_WANDB_ENTITY")

--- a/yucca/pipeline/configuration/configure_callbacks.py
+++ b/yucca/pipeline/configuration/configure_callbacks.py
@@ -8,7 +8,7 @@ from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.profilers.profiler import Profiler
 from yucca.modules.callbacks.loggers import YuccaLogger
 from yucca.modules.callbacks.prediction_writer import WritePredictionFromLogits
-from yucca.paths import yucca_wandb_entity
+from yucca.paths import get_yucca_wandb_entity
 
 
 @dataclass
@@ -104,7 +104,7 @@ def get_loggers(
         version = int(version)
 
     if wandb_entity is None:
-        wandb_entity = yucca_wandb_entity
+        wandb_entity = get_yucca_wandb_entity
 
     loggers = [
         YuccaLogger(

--- a/yucca/pipeline/configuration/configure_paths.py
+++ b/yucca/pipeline/configuration/configure_paths.py
@@ -25,10 +25,10 @@ class PathConfig:
 
 
 def get_path_config(task_config: TaskConfig):
-    task_dir = join(yucca_preprocessed_data, task_config.task)
+    task_dir = join(yucca_preprocessed_data(), task_config.task)
     train_data_dir = join(task_dir, task_config.planner_name)
     save_dir = join(
-        yucca_models,
+        yucca_models(),
         task_config.task,
         task_config.model_name + "__" + task_config.model_dimensions,
         task_config.manager_name + "__" + task_config.planner_name,

--- a/yucca/pipeline/configuration/configure_paths.py
+++ b/yucca/pipeline/configuration/configure_paths.py
@@ -1,7 +1,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, isdir, subdirs, maybe_mkdir_p
 from dataclasses import dataclass
 from typing import Union
-from yucca.paths import get_yucca_models, get_yucca_preprocessed_data
+from yucca.paths import get_models_path, get_preprocessed_data_path
 from yucca.pipeline.configuration.configure_task import TaskConfig
 
 
@@ -25,10 +25,10 @@ class PathConfig:
 
 
 def get_path_config(task_config: TaskConfig):
-    task_dir = join(get_yucca_preprocessed_data(), task_config.task)
+    task_dir = join(get_preprocessed_data_path(), task_config.task)
     train_data_dir = join(task_dir, task_config.planner_name)
     save_dir = join(
-        get_yucca_models(),
+        get_models_path(),
         task_config.task,
         task_config.model_name + "__" + task_config.model_dimensions,
         task_config.manager_name + "__" + task_config.planner_name,

--- a/yucca/pipeline/configuration/configure_paths.py
+++ b/yucca/pipeline/configuration/configure_paths.py
@@ -1,7 +1,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, isdir, subdirs, maybe_mkdir_p
 from dataclasses import dataclass
 from typing import Union
-from yucca.paths import yucca_models, yucca_preprocessed_data
+from yucca.paths import get_yucca_models, get_yucca_preprocessed_data
 from yucca.pipeline.configuration.configure_task import TaskConfig
 
 
@@ -25,10 +25,10 @@ class PathConfig:
 
 
 def get_path_config(task_config: TaskConfig):
-    task_dir = join(yucca_preprocessed_data(), task_config.task)
+    task_dir = join(get_yucca_preprocessed_data(), task_config.task)
     train_data_dir = join(task_dir, task_config.planner_name)
     save_dir = join(
-        yucca_models(),
+        get_yucca_models(),
         task_config.task,
         task_config.model_name + "__" + task_config.model_dimensions,
         task_config.manager_name + "__" + task_config.planner_name,

--- a/yucca/pipeline/evaluation/YuccaEvaluator.py
+++ b/yucca/pipeline/evaluation/YuccaEvaluator.py
@@ -23,7 +23,7 @@ from yucca.functional.evaluation.metrics import (
 )
 from yucca.functional.evaluation.obj_metrics import get_obj_stats_for_label
 from yucca.functional.evaluation.surface_metrics import get_surface_metrics_for_label
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 
 
@@ -175,7 +175,7 @@ class YuccaEvaluator(object):
         gt_is_task = [i for i in self.folder_with_ground_truth.split(os.sep) if "Task" in i]
         if gt_is_task:
             gt_task = gt_is_task[0]
-            dataset_json = join(get_yucca_raw_data(), gt_task, "dataset.json")
+            dataset_json = join(get_raw_data_path(), gt_task, "dataset.json")
             if isfile(dataset_json):
                 dataset_json = load_json(dataset_json)
                 print(f"Labels found in dataset.json: {list(dataset_json['labels'].keys())}")

--- a/yucca/pipeline/evaluation/YuccaEvaluator.py
+++ b/yucca/pipeline/evaluation/YuccaEvaluator.py
@@ -175,7 +175,7 @@ class YuccaEvaluator(object):
         gt_is_task = [i for i in self.folder_with_ground_truth.split(os.sep) if "Task" in i]
         if gt_is_task:
             gt_task = gt_is_task[0]
-            dataset_json = join(yucca_raw_data, gt_task, "dataset.json")
+            dataset_json = join(yucca_raw_data(), gt_task, "dataset.json")
             if isfile(dataset_json):
                 dataset_json = load_json(dataset_json)
                 print(f"Labels found in dataset.json: {list(dataset_json['labels'].keys())}")

--- a/yucca/pipeline/evaluation/YuccaEvaluator.py
+++ b/yucca/pipeline/evaluation/YuccaEvaluator.py
@@ -23,7 +23,7 @@ from yucca.functional.evaluation.metrics import (
 )
 from yucca.functional.evaluation.obj_metrics import get_obj_stats_for_label
 from yucca.functional.evaluation.surface_metrics import get_surface_metrics_for_label
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 
 
@@ -175,7 +175,7 @@ class YuccaEvaluator(object):
         gt_is_task = [i for i in self.folder_with_ground_truth.split(os.sep) if "Task" in i]
         if gt_is_task:
             gt_task = gt_is_task[0]
-            dataset_json = join(yucca_raw_data(), gt_task, "dataset.json")
+            dataset_json = join(get_yucca_raw_data(), gt_task, "dataset.json")
             if isfile(dataset_json):
                 dataset_json = load_json(dataset_json)
                 print(f"Labels found in dataset.json: {list(dataset_json['labels'].keys())}")

--- a/yucca/pipeline/managers/YuccaManager.py
+++ b/yucca/pipeline/managers/YuccaManager.py
@@ -16,7 +16,7 @@ from yucca.modules.data.data_modules.YuccaDataModule import YuccaDataModule
 from yucca.modules.data.datasets.YuccaDataset import YuccaTrainDataset, YuccaTestDataset, YuccaTestPreprocessedDataset
 from yucca.modules.data.samplers import InfiniteRandomSampler
 from yucca.modules.lightning_modules.YuccaLightningModule import YuccaLightningModule
-from yucca.paths import get_yucca_results
+from yucca.paths import get_results_path
 
 
 class YuccaManager:
@@ -291,7 +291,7 @@ class YuccaManager:
         disable_tta: bool = False,
         disable_inference_preprocessing: bool = False,
         overwrite_predictions: bool = False,
-        output_folder: str = get_yucca_results(),
+        output_folder: str = get_results_path(),
         pred_include_cases: list = None,
         save_softmax=False,
     ):
@@ -320,7 +320,7 @@ class YuccaManager:
         input_folder,
         disable_tta: bool = False,
         overwrite_predictions: bool = False,
-        output_folder: str = get_yucca_results(),
+        output_folder: str = get_results_path(),
         pred_include_cases: list = None,
         save_softmax=False,
     ):

--- a/yucca/pipeline/managers/YuccaManager.py
+++ b/yucca/pipeline/managers/YuccaManager.py
@@ -16,7 +16,7 @@ from yucca.modules.data.data_modules.YuccaDataModule import YuccaDataModule
 from yucca.modules.data.datasets.YuccaDataset import YuccaTrainDataset, YuccaTestDataset, YuccaTestPreprocessedDataset
 from yucca.modules.data.samplers import InfiniteRandomSampler
 from yucca.modules.lightning_modules.YuccaLightningModule import YuccaLightningModule
-from yucca.paths import yucca_results
+from yucca.paths import get_yucca_results
 
 
 class YuccaManager:
@@ -291,7 +291,7 @@ class YuccaManager:
         disable_tta: bool = False,
         disable_inference_preprocessing: bool = False,
         overwrite_predictions: bool = False,
-        output_folder: str = yucca_results(),
+        output_folder: str = get_yucca_results(),
         pred_include_cases: list = None,
         save_softmax=False,
     ):
@@ -320,7 +320,7 @@ class YuccaManager:
         input_folder,
         disable_tta: bool = False,
         overwrite_predictions: bool = False,
-        output_folder: str = yucca_results(),
+        output_folder: str = get_yucca_results(),
         pred_include_cases: list = None,
         save_softmax=False,
     ):

--- a/yucca/pipeline/managers/YuccaManager.py
+++ b/yucca/pipeline/managers/YuccaManager.py
@@ -291,7 +291,7 @@ class YuccaManager:
         disable_tta: bool = False,
         disable_inference_preprocessing: bool = False,
         overwrite_predictions: bool = False,
-        output_folder: str = yucca_results,
+        output_folder: str = yucca_results(),
         pred_include_cases: list = None,
         save_softmax=False,
     ):
@@ -320,7 +320,7 @@ class YuccaManager:
         input_folder,
         disable_tta: bool = False,
         overwrite_predictions: bool = False,
-        output_folder: str = yucca_results,
+        output_folder: str = yucca_results(),
         pred_include_cases: list = None,
         save_softmax=False,
     ):

--- a/yucca/pipeline/planning/YuccaPlanner.py
+++ b/yucca/pipeline/planning/YuccaPlanner.py
@@ -1,7 +1,7 @@
 from yucca.pipeline.preprocessing import ClassificationPreprocessor
 import yucca
 import numpy as np
-from yucca.paths import get_yucca_preprocessed_data, get_yucca_raw_data
+from yucca.paths import get_preprocessed_data_path, get_raw_data_path
 from yucca.pipeline.planning.dataset_properties import create_dataset_properties
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, isfile, load_pickle, save_json
@@ -183,8 +183,8 @@ class YuccaPlanner(object):
 
     def set_paths(self):
         # Setting up paths
-        self.in_dir = join(get_yucca_raw_data(), self.task)
-        self.target_dir = join(get_yucca_preprocessed_data(), self.task)
+        self.in_dir = join(get_raw_data_path(), self.task)
+        self.target_dir = join(get_preprocessed_data_path(), self.task)
         self.plans_folder = join(self.target_dir, self.name)
         self.plans_path = join(self.plans_folder, self.name + "_plans.json")
         maybe_mkdir_p(join(self.target_dir, self.name))

--- a/yucca/pipeline/planning/YuccaPlanner.py
+++ b/yucca/pipeline/planning/YuccaPlanner.py
@@ -183,8 +183,8 @@ class YuccaPlanner(object):
 
     def set_paths(self):
         # Setting up paths
-        self.in_dir = join(yucca_raw_data, self.task)
-        self.target_dir = join(yucca_preprocessed_data, self.task)
+        self.in_dir = join(yucca_raw_data(), self.task)
+        self.target_dir = join(yucca_preprocessed_data(), self.task)
         self.plans_folder = join(self.target_dir, self.name)
         self.plans_path = join(self.plans_folder, self.name + "_plans.json")
         maybe_mkdir_p(join(self.target_dir, self.name))

--- a/yucca/pipeline/planning/YuccaPlanner.py
+++ b/yucca/pipeline/planning/YuccaPlanner.py
@@ -1,7 +1,7 @@
 from yucca.pipeline.preprocessing import ClassificationPreprocessor
 import yucca
 import numpy as np
-from yucca.paths import yucca_preprocessed_data, yucca_raw_data
+from yucca.paths import get_yucca_preprocessed_data, get_yucca_raw_data
 from yucca.pipeline.planning.dataset_properties import create_dataset_properties
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, isfile, load_pickle, save_json
@@ -183,8 +183,8 @@ class YuccaPlanner(object):
 
     def set_paths(self):
         # Setting up paths
-        self.in_dir = join(yucca_raw_data(), self.task)
-        self.target_dir = join(yucca_preprocessed_data(), self.task)
+        self.in_dir = join(get_yucca_raw_data(), self.task)
+        self.target_dir = join(get_yucca_preprocessed_data(), self.task)
         self.plans_folder = join(self.target_dir, self.name)
         self.plans_path = join(self.plans_folder, self.name + "_plans.json")
         maybe_mkdir_p(join(self.target_dir, self.name))

--- a/yucca/pipeline/preprocessing/UnsupervisedPreprocessor.py
+++ b/yucca/pipeline/preprocessing/UnsupervisedPreprocessor.py
@@ -1,6 +1,6 @@
 import re
 from yucca.pipeline.preprocessing.YuccaPreprocessor import YuccaPreprocessor
-from yucca.paths import yucca_preprocessed_data, yucca_raw_data
+from yucca.paths import get_yucca_preprocessed_data, get_yucca_raw_data
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
     subfiles,
@@ -18,8 +18,8 @@ class UnsupervisedPreprocessor(YuccaPreprocessor):
     def initialize_paths(self):
         # Have to overwrite how we get the subject_ids as there's no labelsTr to get them from.
         # Therefore we use the imagesTr folder and remove the modality suffix.
-        self.target_dir = join(yucca_preprocessed_data(), self.task, self.plans["plans_name"])
-        self.input_dir = join(yucca_raw_data(), self.task)
+        self.target_dir = join(get_yucca_preprocessed_data(), self.task, self.plans["plans_name"])
+        self.input_dir = join(get_yucca_raw_data(), self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
 
         subject_ids = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension, join=False)

--- a/yucca/pipeline/preprocessing/UnsupervisedPreprocessor.py
+++ b/yucca/pipeline/preprocessing/UnsupervisedPreprocessor.py
@@ -18,8 +18,8 @@ class UnsupervisedPreprocessor(YuccaPreprocessor):
     def initialize_paths(self):
         # Have to overwrite how we get the subject_ids as there's no labelsTr to get them from.
         # Therefore we use the imagesTr folder and remove the modality suffix.
-        self.target_dir = join(yucca_preprocessed_data, self.task, self.plans["plans_name"])
-        self.input_dir = join(yucca_raw_data, self.task)
+        self.target_dir = join(yucca_preprocessed_data(), self.task, self.plans["plans_name"])
+        self.input_dir = join(yucca_raw_data(), self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
 
         subject_ids = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension, join=False)

--- a/yucca/pipeline/preprocessing/UnsupervisedPreprocessor.py
+++ b/yucca/pipeline/preprocessing/UnsupervisedPreprocessor.py
@@ -1,6 +1,6 @@
 import re
 from yucca.pipeline.preprocessing.YuccaPreprocessor import YuccaPreprocessor
-from yucca.paths import get_yucca_preprocessed_data, get_yucca_raw_data
+from yucca.paths import get_preprocessed_data_path, get_raw_data_path
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
     subfiles,
@@ -18,8 +18,8 @@ class UnsupervisedPreprocessor(YuccaPreprocessor):
     def initialize_paths(self):
         # Have to overwrite how we get the subject_ids as there's no labelsTr to get them from.
         # Therefore we use the imagesTr folder and remove the modality suffix.
-        self.target_dir = join(get_yucca_preprocessed_data(), self.task, self.plans["plans_name"])
-        self.input_dir = join(get_yucca_raw_data(), self.task)
+        self.target_dir = join(get_preprocessed_data_path(), self.task, self.plans["plans_name"])
+        self.input_dir = join(get_raw_data_path(), self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
 
         subject_ids = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension, join=False)

--- a/yucca/pipeline/preprocessing/YuccaPreprocessor.py
+++ b/yucca/pipeline/preprocessing/YuccaPreprocessor.py
@@ -92,8 +92,8 @@ class YuccaPreprocessor(object):
         self.preprocess_label = True
 
     def initialize_paths(self):
-        self.target_dir = join(yucca_preprocessed_data, self.task, self.plans["plans_name"])
-        self.input_dir = join(yucca_raw_data, self.task)
+        self.target_dir = join(yucca_preprocessed_data(), self.task, self.plans["plans_name"])
+        self.input_dir = join(yucca_raw_data(), self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
         self.subject_ids = [
             file for file in subfiles(join(self.input_dir, "labelsTr"), join=False) if not file.startswith(".")

--- a/yucca/pipeline/preprocessing/YuccaPreprocessor.py
+++ b/yucca/pipeline/preprocessing/YuccaPreprocessor.py
@@ -17,7 +17,7 @@ from yucca.functional.preprocessing import (
     reverse_preprocessing,
 )
 from yucca.functional.utils.loading import load_yaml, read_file_to_nifti_or_np
-from yucca.paths import get_yucca_preprocessed_data, get_yucca_raw_data
+from yucca.paths import get_preprocessed_data_path, get_raw_data_path
 from multiprocessing import Pool
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
@@ -92,8 +92,8 @@ class YuccaPreprocessor(object):
         self.preprocess_label = True
 
     def initialize_paths(self):
-        self.target_dir = join(get_yucca_preprocessed_data(), self.task, self.plans["plans_name"])
-        self.input_dir = join(get_yucca_raw_data(), self.task)
+        self.target_dir = join(get_preprocessed_data_path(), self.task, self.plans["plans_name"])
+        self.input_dir = join(get_raw_data_path(), self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
         self.subject_ids = [
             file for file in subfiles(join(self.input_dir, "labelsTr"), join=False) if not file.startswith(".")

--- a/yucca/pipeline/preprocessing/YuccaPreprocessor.py
+++ b/yucca/pipeline/preprocessing/YuccaPreprocessor.py
@@ -17,7 +17,7 @@ from yucca.functional.preprocessing import (
     reverse_preprocessing,
 )
 from yucca.functional.utils.loading import load_yaml, read_file_to_nifti_or_np
-from yucca.paths import yucca_preprocessed_data, yucca_raw_data
+from yucca.paths import get_yucca_preprocessed_data, get_yucca_raw_data
 from multiprocessing import Pool
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
@@ -92,8 +92,8 @@ class YuccaPreprocessor(object):
         self.preprocess_label = True
 
     def initialize_paths(self):
-        self.target_dir = join(yucca_preprocessed_data(), self.task, self.plans["plans_name"])
-        self.input_dir = join(yucca_raw_data(), self.task)
+        self.target_dir = join(get_yucca_preprocessed_data(), self.task, self.plans["plans_name"])
+        self.input_dir = join(get_yucca_raw_data(), self.task)
         self.imagepaths = subfiles(join(self.input_dir, "imagesTr"), suffix=self.image_extension)
         self.subject_ids = [
             file for file in subfiles(join(self.input_dir, "labelsTr"), join=False) if not file.startswith(".")

--- a/yucca/pipeline/run/run_evaluation.py
+++ b/yucca/pipeline/run/run_evaluation.py
@@ -118,7 +118,7 @@ def main():
             target_task = source_task
 
         predpath = join(  # TODO: Extract this into a function
-            yucca_results,
+            yucca_results(),
             target_task,
             source_task,
             model + "__" + dimensions,
@@ -128,8 +128,8 @@ def main():
             "version_" + str(num_version),
             checkpoint,
         )
-        gtpath = join(yucca_raw_data, target_task, "labelsTs")
-        classes = list(load_json(join(yucca_raw_data, target_task, "dataset.json"))["labels"].keys())
+        gtpath = join(yucca_raw_data(), target_task, "labelsTs")
+        classes = list(load_json(join(yucca_raw_data(), target_task, "dataset.json"))["labels"].keys())
 
     evaluator = YuccaEvaluator(
         classes,

--- a/yucca/pipeline/run/run_evaluation.py
+++ b/yucca/pipeline/run/run_evaluation.py
@@ -12,7 +12,7 @@ import argparse
 from batchgenerators.utilities.file_and_folder_operations import load_json, join
 from yucca.pipeline.evaluation.YuccaEvaluator import YuccaEvaluator
 from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
-from yucca.paths import yucca_raw_data, yucca_results
+from yucca.paths import get_yucca_raw_data, get_yucca_results
 
 
 def main():
@@ -118,7 +118,7 @@ def main():
             target_task = source_task
 
         predpath = join(  # TODO: Extract this into a function
-            yucca_results(),
+            get_yucca_results(),
             target_task,
             source_task,
             model + "__" + dimensions,
@@ -128,8 +128,8 @@ def main():
             "version_" + str(num_version),
             checkpoint,
         )
-        gtpath = join(yucca_raw_data(), target_task, "labelsTs")
-        classes = list(load_json(join(yucca_raw_data(), target_task, "dataset.json"))["labels"].keys())
+        gtpath = join(get_yucca_raw_data(), target_task, "labelsTs")
+        classes = list(load_json(join(get_yucca_raw_data(), target_task, "dataset.json"))["labels"].keys())
 
     evaluator = YuccaEvaluator(
         classes,

--- a/yucca/pipeline/run/run_evaluation.py
+++ b/yucca/pipeline/run/run_evaluation.py
@@ -12,7 +12,7 @@ import argparse
 from batchgenerators.utilities.file_and_folder_operations import load_json, join
 from yucca.pipeline.evaluation.YuccaEvaluator import YuccaEvaluator
 from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
-from yucca.paths import get_yucca_raw_data, get_yucca_results
+from yucca.paths import get_raw_data_path, get_results_path
 
 
 def main():
@@ -118,7 +118,7 @@ def main():
             target_task = source_task
 
         predpath = join(  # TODO: Extract this into a function
-            get_yucca_results(),
+            get_results_path(),
             target_task,
             source_task,
             model + "__" + dimensions,
@@ -128,8 +128,8 @@ def main():
             "version_" + str(num_version),
             checkpoint,
         )
-        gtpath = join(get_yucca_raw_data(), target_task, "labelsTs")
-        classes = list(load_json(join(get_yucca_raw_data(), target_task, "dataset.json"))["labels"].keys())
+        gtpath = join(get_raw_data_path(), target_task, "labelsTs")
+        classes = list(load_json(join(get_raw_data_path(), target_task, "dataset.json"))["labels"].keys())
 
     evaluator = YuccaEvaluator(
         classes,

--- a/yucca/pipeline/run/run_inference.py
+++ b/yucca/pipeline/run/run_inference.py
@@ -1,7 +1,12 @@
 import argparse
 import yucca
 from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
-from yucca.paths import get_yucca_raw_data, get_yucca_results, get_yucca_models, get_yucca_preprocessed_data
+from yucca.paths import (
+    get_raw_data_path,
+    get_results_path,
+    get_models_path,
+    get_preprocessed_data_path,
+)
 from yucca.pipeline.evaluation.YuccaEvaluator import YuccaEvaluator
 from yucca.pipeline.managers.YuccaManager import YuccaManager
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
@@ -177,7 +182,7 @@ def main():
     split = None
 
     path_to_versions = join(
-        get_yucca_models(),
+        get_models_path(),
         source_task,
         model + "__" + dimensions,
         manager_name + "__" + planner,
@@ -192,7 +197,7 @@ def main():
         checkpoint = "last"
 
     modelfile = join(
-        get_yucca_models(),
+        get_models_path(),
         source_task,
         model + "__" + dimensions,
         manager_name + "__" + planner,
@@ -232,11 +237,11 @@ def main():
     )
 
     # Setting up input paths and output paths
-    inpath = join(get_yucca_raw_data(), target_task, "imagesTs") if not predpath else predpath
-    ground_truth = join(get_yucca_raw_data(), target_task, "labelsTs") if not gtpath else gtpath
+    inpath = join(get_raw_data_path(), target_task, "imagesTs") if not predpath else predpath
+    ground_truth = join(get_raw_data_path(), target_task, "labelsTs") if not gtpath else gtpath
 
     outpath = join(
-        get_yucca_results(),
+        get_results_path(),
         target_task,
         source_task,
         model + "__" + dimensions,
@@ -248,14 +253,14 @@ def main():
     )
 
     if predict_train:
-        inpath = join(get_yucca_raw_data(), target_task, "imagesTr")
-        ground_truth = join(get_yucca_raw_data(), target_task, "labelsTr")
+        inpath = join(get_raw_data_path(), target_task, "imagesTr")
+        ground_truth = join(get_raw_data_path(), target_task, "labelsTr")
         outpath += "Tr"
     elif predict_val:
-        inpath = join(get_yucca_raw_data(), target_task, "imagesTr")
-        ground_truth = join(get_yucca_raw_data(), target_task, "labelsTr")
+        inpath = join(get_raw_data_path(), target_task, "imagesTr")
+        ground_truth = join(get_raw_data_path(), target_task, "labelsTr")
         outpath += "Val"
-        split = load_pickle(join(get_yucca_preprocessed_data(), source_task, "splits.pkl"))
+        split = load_pickle(join(get_preprocessed_data_path(), source_task, "splits.pkl"))
         split = split[str(split_data_method)][split_data_param][split_idx]["val"]
         strict = False
 

--- a/yucca/pipeline/run/run_inference.py
+++ b/yucca/pipeline/run/run_inference.py
@@ -1,7 +1,7 @@
 import argparse
 import yucca
 from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
-from yucca.paths import yucca_raw_data, yucca_results, yucca_models, yucca_preprocessed_data
+from yucca.paths import get_yucca_raw_data, get_yucca_results, get_yucca_models, get_yucca_preprocessed_data
 from yucca.pipeline.evaluation.YuccaEvaluator import YuccaEvaluator
 from yucca.pipeline.managers.YuccaManager import YuccaManager
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
@@ -177,7 +177,7 @@ def main():
     split = None
 
     path_to_versions = join(
-        yucca_models(),
+        get_yucca_models(),
         source_task,
         model + "__" + dimensions,
         manager_name + "__" + planner,
@@ -192,7 +192,7 @@ def main():
         checkpoint = "last"
 
     modelfile = join(
-        yucca_models(),
+        get_yucca_models(),
         source_task,
         model + "__" + dimensions,
         manager_name + "__" + planner,
@@ -232,11 +232,11 @@ def main():
     )
 
     # Setting up input paths and output paths
-    inpath = join(yucca_raw_data(), target_task, "imagesTs") if not predpath else predpath
-    ground_truth = join(yucca_raw_data(), target_task, "labelsTs") if not gtpath else gtpath
+    inpath = join(get_yucca_raw_data(), target_task, "imagesTs") if not predpath else predpath
+    ground_truth = join(get_yucca_raw_data(), target_task, "labelsTs") if not gtpath else gtpath
 
     outpath = join(
-        yucca_results(),
+        get_yucca_results(),
         target_task,
         source_task,
         model + "__" + dimensions,
@@ -248,14 +248,14 @@ def main():
     )
 
     if predict_train:
-        inpath = join(yucca_raw_data(), target_task, "imagesTr")
-        ground_truth = join(yucca_raw_data(), target_task, "labelsTr")
+        inpath = join(get_yucca_raw_data(), target_task, "imagesTr")
+        ground_truth = join(get_yucca_raw_data(), target_task, "labelsTr")
         outpath += "Tr"
     elif predict_val:
-        inpath = join(yucca_raw_data(), target_task, "imagesTr")
-        ground_truth = join(yucca_raw_data(), target_task, "labelsTr")
+        inpath = join(get_yucca_raw_data(), target_task, "imagesTr")
+        ground_truth = join(get_yucca_raw_data(), target_task, "labelsTr")
         outpath += "Val"
-        split = load_pickle(join(yucca_preprocessed_data(), source_task, "splits.pkl"))
+        split = load_pickle(join(get_yucca_preprocessed_data(), source_task, "splits.pkl"))
         split = split[str(split_data_method)][split_data_param][split_idx]["val"]
         strict = False
 

--- a/yucca/pipeline/run/run_inference.py
+++ b/yucca/pipeline/run/run_inference.py
@@ -177,7 +177,7 @@ def main():
     split = None
 
     path_to_versions = join(
-        yucca_models,
+        yucca_models(),
         source_task,
         model + "__" + dimensions,
         manager_name + "__" + planner,
@@ -192,7 +192,7 @@ def main():
         checkpoint = "last"
 
     modelfile = join(
-        yucca_models,
+        yucca_models(),
         source_task,
         model + "__" + dimensions,
         manager_name + "__" + planner,
@@ -232,11 +232,11 @@ def main():
     )
 
     # Setting up input paths and output paths
-    inpath = join(yucca_raw_data, target_task, "imagesTs") if not predpath else predpath
-    ground_truth = join(yucca_raw_data, target_task, "labelsTs") if not gtpath else gtpath
+    inpath = join(yucca_raw_data(), target_task, "imagesTs") if not predpath else predpath
+    ground_truth = join(yucca_raw_data(), target_task, "labelsTs") if not gtpath else gtpath
 
     outpath = join(
-        yucca_results,
+        yucca_results(),
         target_task,
         source_task,
         model + "__" + dimensions,
@@ -248,14 +248,14 @@ def main():
     )
 
     if predict_train:
-        inpath = join(yucca_raw_data, target_task, "imagesTr")
-        ground_truth = join(yucca_raw_data, target_task, "labelsTr")
+        inpath = join(yucca_raw_data(), target_task, "imagesTr")
+        ground_truth = join(yucca_raw_data(), target_task, "labelsTr")
         outpath += "Tr"
     elif predict_val:
-        inpath = join(yucca_raw_data, target_task, "imagesTr")
-        ground_truth = join(yucca_raw_data, target_task, "labelsTr")
+        inpath = join(yucca_raw_data(), target_task, "imagesTr")
+        ground_truth = join(yucca_raw_data(), target_task, "labelsTr")
         outpath += "Val"
-        split = load_pickle(join(yucca_preprocessed_data, source_task, "splits.pkl"))
+        split = load_pickle(join(yucca_preprocessed_data(), source_task, "splits.pkl"))
         split = split[str(split_data_method)][split_data_param][split_idx]["val"]
         strict = False
 

--- a/yucca/pipeline/run/run_task_conversion.py
+++ b/yucca/pipeline/run/run_task_conversion.py
@@ -1,5 +1,5 @@
 import argparse
-from yucca.paths import get_yucca_source
+from yucca.paths import get_source_path
 import importlib
 import re
 
@@ -20,7 +20,7 @@ def main():
     parser.add_argument(
         "-t", "--task", help="Name of the task to preprocess. " "Should be of format: TaskXXX_MYTASK", required=True
     )
-    parser.add_argument("-p", "--path", help="Path to source data", default=get_yucca_source())
+    parser.add_argument("-p", "--path", help="Path to source data", default=get_source_path())
     parser.add_argument("-d", "--subdir", help="Directory of data inside source data")
 
     args = parser.parse_args()

--- a/yucca/pipeline/run/run_task_conversion.py
+++ b/yucca/pipeline/run/run_task_conversion.py
@@ -1,5 +1,5 @@
 import argparse
-from yucca.paths import yucca_source
+from yucca.paths import get_yucca_source
 import importlib
 import re
 
@@ -20,7 +20,7 @@ def main():
     parser.add_argument(
         "-t", "--task", help="Name of the task to preprocess. " "Should be of format: TaskXXX_MYTASK", required=True
     )
-    parser.add_argument("-p", "--path", help="Path to source data", default=yucca_source())
+    parser.add_argument("-p", "--path", help="Path to source data", default=get_yucca_source())
     parser.add_argument("-d", "--subdir", help="Directory of data inside source data")
 
     args = parser.parse_args()

--- a/yucca/pipeline/run/run_task_conversion.py
+++ b/yucca/pipeline/run/run_task_conversion.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument(
         "-t", "--task", help="Name of the task to preprocess. " "Should be of format: TaskXXX_MYTASK", required=True
     )
-    parser.add_argument("-p", "--path", help="Path to source data", default=yucca_source)
+    parser.add_argument("-p", "--path", help="Path to source data", default=yucca_source())
     parser.add_argument("-d", "--subdir", help="Directory of data inside source data")
 
     args = parser.parse_args()

--- a/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
@@ -2,7 +2,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
@@ -27,7 +27,7 @@ def convert(path: str, subdir: str = "dataset_test0_classification"):
     task_prefix = "TEST_CLASSIFICATION"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
@@ -27,7 +27,7 @@ def convert(path: str, subdir: str = "dataset_test0_classification"):
     task_prefix = "TEST_CLASSIFICATION"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
@@ -2,7 +2,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
@@ -27,7 +27,7 @@ def convert(path: str, subdir: str = "dataset_test0_classification"):
     task_prefix = "TEST_CLASSIFICATION"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
@@ -15,12 +15,12 @@ for i in range(7):
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
 
-def convert(path: str = yucca_source(), subdir: str = "dataset_test0"):
+def convert(path: str = get_yucca_source(), subdir: str = "dataset_test0"):
     # INPUT DATA
     path = join(path, subdir)
     suffix = ".nii.gz"
@@ -37,7 +37,7 @@ def convert(path: str = yucca_source(), subdir: str = "dataset_test0"):
     task_prefix = "TEST_SEGMENTATION"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
@@ -15,12 +15,12 @@ for i in range(7):
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "dataset_test0"):
+def convert(path: str = get_source_path(), subdir: str = "dataset_test0"):
     # INPUT DATA
     path = join(path, subdir)
     suffix = ".nii.gz"
@@ -37,7 +37,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "dataset_test0"):
     task_prefix = "TEST_SEGMENTATION"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
@@ -20,7 +20,7 @@ from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
 
-def convert(path: str = yucca_source, subdir: str = "dataset_test0"):
+def convert(path: str = yucca_source(), subdir: str = "dataset_test0"):
     # INPUT DATA
     path = join(path, subdir)
     suffix = ".nii.gz"
@@ -37,7 +37,7 @@ def convert(path: str = yucca_source, subdir: str = "dataset_test0"):
     task_prefix = "TEST_SEGMENTATION"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
@@ -37,7 +37,7 @@ def convert(path: str, subdir: str = "dataset_test0"):
     task_prefix = "TEST_UNSUPERVISED"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
 

--- a/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
@@ -15,7 +15,7 @@ for i in range(7):
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
@@ -37,7 +37,7 @@ def convert(path: str, subdir: str = "dataset_test0"):
     task_prefix = "TEST_UNSUPERVISED"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
 

--- a/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
@@ -15,7 +15,7 @@ for i in range(7):
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 from sklearn.model_selection import train_test_split
 
@@ -37,7 +37,7 @@ def convert(path: str, subdir: str = "dataset_test0"):
     task_prefix = "TEST_UNSUPERVISED"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
 

--- a/yucca/pipeline/task_conversion/Task001_OASIS.py
+++ b/yucca/pipeline/task_conversion/Task001_OASIS.py
@@ -34,7 +34,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 
 
@@ -58,7 +58,7 @@ def convert(path: str, subdir: str = "OASIS"):
     prefix = "OASIS"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task001_OASIS.py
+++ b/yucca/pipeline/task_conversion/Task001_OASIS.py
@@ -34,7 +34,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 
 
@@ -58,7 +58,7 @@ def convert(path: str, subdir: str = "OASIS"):
     prefix = "OASIS"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task001_OASIS.py
+++ b/yucca/pipeline/task_conversion/Task001_OASIS.py
@@ -58,7 +58,7 @@ def convert(path: str, subdir: str = "OASIS"):
     prefix = "OASIS"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task002_LPBA40.py
+++ b/yucca/pipeline/task_conversion/Task002_LPBA40.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 
 
@@ -29,7 +29,7 @@ def convert(path: str, subdir: str = "LPBA40"):
     prefix = "LPBA40"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task002_LPBA40.py
+++ b/yucca/pipeline/task_conversion/Task002_LPBA40.py
@@ -29,7 +29,7 @@ def convert(path: str, subdir: str = "LPBA40"):
     prefix = "LPBA40"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task002_LPBA40.py
+++ b/yucca/pipeline/task_conversion/Task002_LPBA40.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 
 
@@ -29,7 +29,7 @@ def convert(path: str, subdir: str = "LPBA40"):
     prefix = "LPBA40"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task003_Hammers.py
+++ b/yucca/pipeline/task_conversion/Task003_Hammers.py
@@ -35,7 +35,7 @@ def convert(path: str, subdir: str = "Hammers"):
     prefix = "Hammers"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task003_Hammers.py
+++ b/yucca/pipeline/task_conversion/Task003_Hammers.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 
 
@@ -35,7 +35,7 @@ def convert(path: str, subdir: str = "Hammers"):
     prefix = "Hammers"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task003_Hammers.py
+++ b/yucca/pipeline/task_conversion/Task003_Hammers.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 
 
@@ -35,7 +35,7 @@ def convert(path: str, subdir: str = "Hammers"):
     prefix = "Hammers"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task004_HarP.py
+++ b/yucca/pipeline/task_conversion/Task004_HarP.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "HarP"):
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "HarP"):
     prefix = "HarP"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task004_HarP.py
+++ b/yucca/pipeline/task_conversion/Task004_HarP.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "HarP"):
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "HarP"):
     prefix = "HarP"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task004_HarP.py
+++ b/yucca/pipeline/task_conversion/Task004_HarP.py
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "HarP"):
     prefix = "HarP"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task005_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task005_ISLES22.py
@@ -3,7 +3,7 @@ import nibabel.processing as nibpro
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     prefix = "ISLES22_FULL"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task005_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task005_ISLES22.py
@@ -3,7 +3,7 @@ import nibabel.processing as nibpro
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     prefix = "ISLES22_FULL"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task005_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task005_ISLES22.py
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     prefix = "ISLES22_FULL"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
+++ b/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
+++ b/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
+++ b/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task007_WMH_T1.py
+++ b/yucca/pipeline/task_conversion/Task007_WMH_T1.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task007_WMH_T1.py
+++ b/yucca/pipeline/task_conversion/Task007_WMH_T1.py
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task007_WMH_T1.py
+++ b/yucca/pipeline/task_conversion/Task007_WMH_T1.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task008_WMH.py
+++ b/yucca/pipeline/task_conversion/Task008_WMH.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task008_WMH.py
+++ b/yucca/pipeline/task_conversion/Task008_WMH.py
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task008_WMH.py
+++ b/yucca/pipeline/task_conversion/Task008_WMH.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task010_AMOS22.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22.py
@@ -1,7 +1,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "amos22"):
@@ -25,7 +25,7 @@ def convert(path: str, subdir: str = "amos22"):
     prefix = "AMOS22"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task010_AMOS22.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22.py
@@ -1,7 +1,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "amos22"):
@@ -25,7 +25,7 @@ def convert(path: str, subdir: str = "amos22"):
     prefix = "AMOS22"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task010_AMOS22.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22.py
@@ -25,7 +25,7 @@ def convert(path: str, subdir: str = "amos22"):
     prefix = "AMOS22"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
@@ -1,7 +1,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "amos22"):
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "amos22"):
     prefix = "AMOS22TEST"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "amos22"):
     prefix = "AMOS22TEST"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
@@ -1,7 +1,7 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "amos22"):
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "amos22"):
     prefix = "AMOS22TEST"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task011_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task011_MSSEG1.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 import shutil
 
 
@@ -11,7 +11,7 @@ def convert(path: str, subdir: str = "MSSEG1_2016"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task011_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task011_MSSEG1.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 import shutil
 
 
@@ -11,7 +11,7 @@ def convert(path: str, subdir: str = "MSSEG1_2016"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task011_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task011_MSSEG1.py
@@ -11,7 +11,7 @@ def convert(path: str, subdir: str = "MSSEG1_2016"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task012_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task012_BraTS21.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -14,7 +14,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task012_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task012_BraTS21.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -14,7 +14,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task012_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task012_BraTS21.py
@@ -14,7 +14,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task013_AutoPET3.py
+++ b/yucca/pipeline/task_conversion/Task013_AutoPET3.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.task_conversion.utils import generate_dataset_json, remove_punctuation_and_spaces
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 from tqdm import tqdm
 
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "Autopet"):
     task_prefix = "AutoPET3"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task013_AutoPET3.py
+++ b/yucca/pipeline/task_conversion/Task013_AutoPET3.py
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "Autopet"):
     task_prefix = "AutoPET3"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task013_AutoPET3.py
+++ b/yucca/pipeline/task_conversion/Task013_AutoPET3.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.task_conversion.utils import generate_dataset_json, remove_punctuation_and_spaces
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 from tqdm import tqdm
 
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "Autopet"):
     task_prefix = "AutoPET3"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task014_MBAS24.py
+++ b/yucca/pipeline/task_conversion/Task014_MBAS24.py
@@ -2,10 +2,10 @@ import shutil
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "MBAS_Dataset"):
+def convert(path: str = get_source_path(), subdir: str = "MBAS_Dataset"):
     # INPUT DATA
     path = f"{path}/{subdir}"
 
@@ -19,7 +19,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "MBAS_Dataset"):
     task_prefix = "MBAS24"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task014_MBAS24.py
+++ b/yucca/pipeline/task_conversion/Task014_MBAS24.py
@@ -2,10 +2,10 @@ import shutil
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "MBAS_Dataset"):
+def convert(path: str = get_yucca_source(), subdir: str = "MBAS_Dataset"):
     # INPUT DATA
     path = f"{path}/{subdir}"
 
@@ -19,7 +19,7 @@ def convert(path: str = yucca_source(), subdir: str = "MBAS_Dataset"):
     task_prefix = "MBAS24"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task014_MBAS24.py
+++ b/yucca/pipeline/task_conversion/Task014_MBAS24.py
@@ -5,7 +5,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "MBAS_Dataset"):
+def convert(path: str = yucca_source(), subdir: str = "MBAS_Dataset"):
     # INPUT DATA
     path = f"{path}/{subdir}"
 
@@ -19,7 +19,7 @@ def convert(path: str = yucca_source, subdir: str = "MBAS_Dataset"):
     task_prefix = "MBAS24"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
+++ b/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
@@ -6,7 +6,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "AIMS-TBI24"):
+def convert(path: str = yucca_source(), subdir: str = "AIMS-TBI24"):
     # INPUT DATA
     path = f"{path}/{subdir}"
 
@@ -21,7 +21,7 @@ def convert(path: str = yucca_source, subdir: str = "AIMS-TBI24"):
     task_prefix = "TBI24"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
+++ b/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
@@ -3,10 +3,10 @@ import nibabel as nib
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "AIMS-TBI24"):
+def convert(path: str = get_source_path(), subdir: str = "AIMS-TBI24"):
     # INPUT DATA
     path = f"{path}/{subdir}"
 
@@ -21,7 +21,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "AIMS-TBI24"):
     task_prefix = "TBI24"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
+++ b/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
@@ -3,10 +3,10 @@ import nibabel as nib
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "AIMS-TBI24"):
+def convert(path: str = get_yucca_source(), subdir: str = "AIMS-TBI24"):
     # INPUT DATA
     path = f"{path}/{subdir}"
 
@@ -21,7 +21,7 @@ def convert(path: str = yucca_source(), subdir: str = "AIMS-TBI24"):
     task_prefix = "TBI24"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task016_ACDC.py
+++ b/yucca/pipeline/task_conversion/Task016_ACDC.py
@@ -4,7 +4,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "ACDC"):
+def convert(path: str = yucca_source(), subdir: str = "ACDC"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -13,7 +13,7 @@ def convert(path: str = yucca_source, subdir: str = "ACDC"):
     task_name = "Task016_ACDC"
     task_prefix = "ACDC"
 
-    """ Access the input data. If images are not split into train/test, and you wish to randomly 
+    """ Access the input data. If images are not split into train/test, and you wish to randomly
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     images_dir_tr = labels_dir_tr = join(path, "database", "training")
@@ -23,7 +23,7 @@ def convert(path: str = yucca_source, subdir: str = "ACDC"):
     test_samples = subdirs(images_dir_ts, join=False)
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task016_ACDC.py
+++ b/yucca/pipeline/task_conversion/Task016_ACDC.py
@@ -1,10 +1,10 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "ACDC"):
+def convert(path: str = get_yucca_source(), subdir: str = "ACDC"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -23,7 +23,7 @@ def convert(path: str = yucca_source(), subdir: str = "ACDC"):
     test_samples = subdirs(images_dir_ts, join=False)
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task016_ACDC.py
+++ b/yucca/pipeline/task_conversion/Task016_ACDC.py
@@ -1,10 +1,10 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "ACDC"):
+def convert(path: str = get_source_path(), subdir: str = "ACDC"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -23,7 +23,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "ACDC"):
     test_samples = subdirs(images_dir_ts, join=False)
 
     """ Then define target paths """
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task017_BTCV.py
+++ b/yucca/pipeline/task_conversion/Task017_BTCV.py
@@ -4,7 +4,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "BTCV_Abdomen"):
+def convert(path: str = yucca_source(), subdir: str = "BTCV_Abdomen"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -13,7 +13,7 @@ def convert(path: str = yucca_source, subdir: str = "BTCV_Abdomen"):
     task_name = "Task017_BTCV"
     task_prefix = "BTCV"
 
-    """ Access the input data. If images are not split into train/test, and you wish to randomly 
+    """ Access the input data. If images are not split into train/test, and you wish to randomly
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     images_dir_tr = join(path, "RawData", "Training", "img")
@@ -21,7 +21,7 @@ def convert(path: str = yucca_source, subdir: str = "BTCV_Abdomen"):
     images_dir_ts = join(path, "RawData", "Testing", "img")
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task017_BTCV.py
+++ b/yucca/pipeline/task_conversion/Task017_BTCV.py
@@ -1,10 +1,10 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "BTCV_Abdomen"):
+def convert(path: str = get_source_path(), subdir: str = "BTCV_Abdomen"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -21,7 +21,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "BTCV_Abdomen"):
     images_dir_ts = join(path, "RawData", "Testing", "img")
 
     """ Then define target paths """
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task017_BTCV.py
+++ b/yucca/pipeline/task_conversion/Task017_BTCV.py
@@ -1,10 +1,10 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "BTCV_Abdomen"):
+def convert(path: str = get_yucca_source(), subdir: str = "BTCV_Abdomen"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -21,7 +21,7 @@ def convert(path: str = yucca_source(), subdir: str = "BTCV_Abdomen"):
     images_dir_ts = join(path, "RawData", "Testing", "img")
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task018_KITS23.py
+++ b/yucca/pipeline/task_conversion/Task018_KITS23.py
@@ -1,11 +1,11 @@
 import nibabel as nib
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 from yucca.functional.utils.nib_utils import reorient_to_RAS
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "kits23"):
+def convert(path: str = get_source_path(), subdir: str = "kits23"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -20,7 +20,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "kits23"):
     images_dir_tr = labels_dir_tr = join(path, "dataset")
 
     """ Then define target paths """
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task018_KITS23.py
+++ b/yucca/pipeline/task_conversion/Task018_KITS23.py
@@ -1,11 +1,11 @@
 import nibabel as nib
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 from yucca.functional.utils.nib_utils import reorient_to_RAS
 
 
-def convert(path: str = yucca_source(), subdir: str = "kits23"):
+def convert(path: str = get_yucca_source(), subdir: str = "kits23"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -20,7 +20,7 @@ def convert(path: str = yucca_source(), subdir: str = "kits23"):
     images_dir_tr = labels_dir_tr = join(path, "dataset")
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task018_KITS23.py
+++ b/yucca/pipeline/task_conversion/Task018_KITS23.py
@@ -5,7 +5,7 @@ from yucca.paths import yucca_raw_data, yucca_source
 from yucca.functional.utils.nib_utils import reorient_to_RAS
 
 
-def convert(path: str = yucca_source, subdir: str = "kits23"):
+def convert(path: str = yucca_source(), subdir: str = "kits23"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -14,13 +14,13 @@ def convert(path: str = yucca_source, subdir: str = "kits23"):
     task_name = "Task018_KITS23"
     task_prefix = "KITS23"
 
-    """ Access the input data. If images are not split into train/test, and you wish to randomly 
+    """ Access the input data. If images are not split into train/test, and you wish to randomly
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     images_dir_tr = labels_dir_tr = join(path, "dataset")
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task019_LITS.py
+++ b/yucca/pipeline/task_conversion/Task019_LITS.py
@@ -5,7 +5,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "LITS"):
+def convert(path: str = yucca_source(), subdir: str = "LITS"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii"
@@ -14,13 +14,13 @@ def convert(path: str = yucca_source, subdir: str = "LITS"):
     task_name = "Task019_LITS"
     task_prefix = "LITS"
 
-    """ Access the input data. If images are not split into train/test, and you wish to randomly 
+    """ Access the input data. If images are not split into train/test, and you wish to randomly
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     training_batches = [join(path, "Training Batch 1"), join(path, "Training Batch 2")]
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task019_LITS.py
+++ b/yucca/pipeline/task_conversion/Task019_LITS.py
@@ -2,10 +2,10 @@ import shutil
 import gzip
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "LITS"):
+def convert(path: str = get_source_path(), subdir: str = "LITS"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii"
@@ -20,7 +20,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "LITS"):
     training_batches = [join(path, "Training Batch 1"), join(path, "Training Batch 2")]
 
     """ Then define target paths """
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task019_LITS.py
+++ b/yucca/pipeline/task_conversion/Task019_LITS.py
@@ -2,10 +2,10 @@ import shutil
 import gzip
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "LITS"):
+def convert(path: str = get_yucca_source(), subdir: str = "LITS"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii"
@@ -20,7 +20,7 @@ def convert(path: str = yucca_source(), subdir: str = "LITS"):
     training_batches = [join(path, "Training Batch 1"), join(path, "Training Batch 2")]
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task020_ATLAS2.py
+++ b/yucca/pipeline/task_conversion/Task020_ATLAS2.py
@@ -2,10 +2,10 @@ import shutil
 import nibabel as nib
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "ATLAS_2"):
+def convert(path: str = get_source_path(), subdir: str = "ATLAS_2"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -21,7 +21,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "ATLAS_2"):
     # images_dir_ts = labels_dir_ts = join(path, "Testing")
 
     """ Then define target paths """
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task020_ATLAS2.py
+++ b/yucca/pipeline/task_conversion/Task020_ATLAS2.py
@@ -5,7 +5,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "ATLAS_2"):
+def convert(path: str = yucca_source(), subdir: str = "ATLAS_2"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -14,14 +14,14 @@ def convert(path: str = yucca_source, subdir: str = "ATLAS_2"):
     task_name = "Task020_ATLAS2"
     task_prefix = "ATLAS2"
 
-    """ Access the input data. If images are not split into train/test, and you wish to randomly 
+    """ Access the input data. If images are not split into train/test, and you wish to randomly
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     images_dir_tr = labels_dir_tr = join(path, "Training")
     # images_dir_ts = labels_dir_ts = join(path, "Testing")
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task020_ATLAS2.py
+++ b/yucca/pipeline/task_conversion/Task020_ATLAS2.py
@@ -2,10 +2,10 @@ import shutil
 import nibabel as nib
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "ATLAS_2"):
+def convert(path: str = get_yucca_source(), subdir: str = "ATLAS_2"):
     """INPUT DATA - Define input path and suffixes"""
     path = join(path, subdir)
     file_suffix = ".nii.gz"
@@ -21,7 +21,7 @@ def convert(path: str = yucca_source(), subdir: str = "ATLAS_2"):
     # images_dir_ts = labels_dir_ts = join(path, "Testing")
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
@@ -3,11 +3,11 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
-def convert(path: str = yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
+def convert(path: str = get_yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
     # INPUT DATA
     path = f"{path}/{subdir}/{subsubdir}"
 
@@ -24,7 +24,7 @@ def convert(path: str = yucca_source(), subdir: str = "decathlon", subsubdir: st
     task_prefix = "Decathlon_BrainTumour"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
@@ -7,7 +7,7 @@ from yucca.paths import yucca_raw_data, yucca_source
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
-def convert(path: str = yucca_source, subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
+def convert(path: str = yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
     # INPUT DATA
     path = f"{path}/{subdir}/{subsubdir}"
 
@@ -24,7 +24,7 @@ def convert(path: str = yucca_source, subdir: str = "decathlon", subsubdir: str 
     task_prefix = "Decathlon_BrainTumour"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
@@ -3,11 +3,11 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
+def convert(path: str = get_source_path(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
     # INPUT DATA
     path = f"{path}/{subdir}/{subsubdir}"
 
@@ -24,7 +24,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "decathlon", subsubdir
     task_prefix = "Decathlon_BrainTumour"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
+++ b/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
@@ -18,7 +18,7 @@ task_name = "Task022_Heart"
 task_prefix = "Heart"
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
+++ b/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
@@ -3,7 +3,7 @@ import shutil
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -18,7 +18,7 @@ task_name = "Task022_Heart"
 task_prefix = "Heart"
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
+++ b/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
@@ -3,7 +3,7 @@ import shutil
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -18,7 +18,7 @@ task_name = "Task022_Heart"
 task_prefix = "Heart"
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
+++ b/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task03_Liver
     task_prefix = "Decathlon_Liver"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
+++ b/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task03_Liver
     task_prefix = "Decathlon_Liver"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
+++ b/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task03_Liver
     task_prefix = "Decathlon_Liver"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task08_Hepat
     task_prefix = "Decathlon_HepaticVessel"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task08_Hepat
     task_prefix = "Decathlon_HepaticVessel"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
 
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task08_Hepat
     task_prefix = "Decathlon_HepaticVessel"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
@@ -1,10 +1,10 @@
 import nibabel as nib
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data, get_yucca_source
+from yucca.paths import get_raw_data_path, get_source_path
 
 
-def convert(path: str = get_yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
+def convert(path: str = get_source_path(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
     # INPUT DATA
     path = f"{path}/{subdir}/{subsubdir}"
 
@@ -20,7 +20,7 @@ def convert(path: str = get_yucca_source(), subdir: str = "decathlon", subsubdir
     task_name = "Task031_MSD_BrainTumour"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
@@ -4,7 +4,7 @@ from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import yucca_raw_data, yucca_source
 
 
-def convert(path: str = yucca_source, subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
+def convert(path: str = yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
     # INPUT DATA
     path = f"{path}/{subdir}/{subsubdir}"
 
@@ -20,7 +20,7 @@ def convert(path: str = yucca_source, subdir: str = "decathlon", subsubdir: str 
     task_name = "Task031_MSD_BrainTumour"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
@@ -1,10 +1,10 @@
 import nibabel as nib
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data, yucca_source
+from yucca.paths import get_yucca_raw_data, get_yucca_source
 
 
-def convert(path: str = yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
+def convert(path: str = get_yucca_source(), subdir: str = "decathlon", subsubdir: str = "Task01_BrainTumour"):
     # INPUT DATA
     path = f"{path}/{subdir}/{subsubdir}"
 
@@ -20,7 +20,7 @@ def convert(path: str = yucca_source(), subdir: str = "decathlon", subsubdir: st
     task_name = "Task031_MSD_BrainTumour"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
+++ b/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task032_MSD_Heart"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
+++ b/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task032_MSD_Heart"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
+++ b/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
@@ -17,7 +17,7 @@ task_name = "Task032_MSD_Heart"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
+++ b/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task033_MSD_Liver"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
+++ b/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task033_MSD_Liver"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
+++ b/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
@@ -17,7 +17,7 @@ task_name = "Task033_MSD_Liver"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
@@ -17,7 +17,7 @@ task_name = "Task034_MSD_Hippocampus"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task034_MSD_Hippocampus"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task034_MSD_Hippocampus"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
+++ b/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task035_MSD_Prostate"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
+++ b/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
@@ -17,7 +17,7 @@ task_name = "Task035_MSD_Prostate"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
+++ b/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task035_MSD_Prostate"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
+++ b/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task036_MSD_Lung"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
+++ b/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
@@ -17,7 +17,7 @@ task_name = "Task036_MSD_Lung"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
+++ b/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task036_MSD_Lung"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
+++ b/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task037_MSD_Pancreas"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
+++ b/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
@@ -17,7 +17,7 @@ task_name = "Task037_MSD_Pancreas"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
+++ b/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task037_MSD_Pancreas"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task038_MSD_HepaticVessel"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task038_MSD_HepaticVessel"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
@@ -17,7 +17,7 @@ task_name = "Task038_MSD_HepaticVessel"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
+++ b/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task039_MSD_Spleen"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
+++ b/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
@@ -17,7 +17,7 @@ task_name = "Task039_MSD_Spleen"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
+++ b/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task039_MSD_Spleen"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
+++ b/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
+++ b/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
+++ b/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
+++ b/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task040_MSD_Colon"
 task_prefix = ""
 
 # Set target paths
-target_base = join(get_yucca_raw_data(), task_name)
+target_base = join(get_raw_data_path(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
+++ b/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
@@ -17,7 +17,7 @@ task_name = "Task040_MSD_Colon"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data, task_name)
+target_base = join(yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
+++ b/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
@@ -2,7 +2,7 @@ import nibabel as nib
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
 
 # INPUT DATA
@@ -17,7 +17,7 @@ task_name = "Task040_MSD_Colon"
 task_prefix = ""
 
 # Set target paths
-target_base = join(yucca_raw_data(), task_name)
+target_base = join(get_yucca_raw_data(), task_name)
 target_imagesTr = join(target_base, "imagesTr")
 target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
+++ b/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
+++ b/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
+++ b/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
+++ b/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
+++ b/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
+++ b/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
+++ b/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
+++ b/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
+++ b/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from sklearn.model_selection import train_test_split
 import nibabel as nib
 import numpy as np
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "brats21/training_data"):
 
     ###OUTPUT DATA
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task100_combine_001_002.py
+++ b/yucca/pipeline/task_conversion/Task100_combine_001_002.py
@@ -19,8 +19,8 @@ def convert(_path: str, _subdir: str = ""):
 
     ### In most cases the remaining can be left untouched ###
     # Setting the paths to save the new task and making the directories
-    target_base = os.path.join(yucca_raw_data, task_name)
-    target_imagesTr = os.path.join(yucca_raw_data, task_name, "imagesTr")
+    target_base = os.path.join(yucca_raw_data(), task_name)
+    target_imagesTr = os.path.join(yucca_raw_data(), task_name, "imagesTr")
     target_imagesTs = None
     os.makedirs(target_imagesTr, exist_ok=True)
 

--- a/yucca/pipeline/task_conversion/Task100_combine_001_002.py
+++ b/yucca/pipeline/task_conversion/Task100_combine_001_002.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_imagesTr_from_tasks, generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(_path: str, _subdir: str = ""):
@@ -19,8 +19,8 @@ def convert(_path: str, _subdir: str = ""):
 
     ### In most cases the remaining can be left untouched ###
     # Setting the paths to save the new task and making the directories
-    target_base = os.path.join(yucca_raw_data(), task_name)
-    target_imagesTr = os.path.join(yucca_raw_data(), task_name, "imagesTr")
+    target_base = os.path.join(get_yucca_raw_data(), task_name)
+    target_imagesTr = os.path.join(get_yucca_raw_data(), task_name, "imagesTr")
     target_imagesTs = None
     os.makedirs(target_imagesTr, exist_ok=True)
 

--- a/yucca/pipeline/task_conversion/Task100_combine_001_002.py
+++ b/yucca/pipeline/task_conversion/Task100_combine_001_002.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_imagesTr_from_tasks, generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(_path: str, _subdir: str = ""):
@@ -19,8 +19,8 @@ def convert(_path: str, _subdir: str = ""):
 
     ### In most cases the remaining can be left untouched ###
     # Setting the paths to save the new task and making the directories
-    target_base = os.path.join(get_yucca_raw_data(), task_name)
-    target_imagesTr = os.path.join(get_yucca_raw_data(), task_name, "imagesTr")
+    target_base = os.path.join(get_raw_data_path(), task_name)
+    target_imagesTr = os.path.join(get_raw_data_path(), task_name, "imagesTr")
     target_imagesTs = None
     os.makedirs(target_imagesTr, exist_ok=True)
 

--- a/yucca/pipeline/task_conversion/Task201_PPMI.py
+++ b/yucca/pipeline/task_conversion/Task201_PPMI.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from datetime import datetime
 from tqdm import tqdm
 import nibabel as nib
@@ -39,7 +39,7 @@ def convert(path: str, subdir: str = "PPMI"):
     task_prefix = "PPMI"
 
     subjects_dir = join(path, "DATA")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task201_PPMI.py
+++ b/yucca/pipeline/task_conversion/Task201_PPMI.py
@@ -39,7 +39,7 @@ def convert(path: str, subdir: str = "PPMI"):
     task_prefix = "PPMI"
 
     subjects_dir = join(path, "DATA")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task201_PPMI.py
+++ b/yucca/pipeline/task_conversion/Task201_PPMI.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from datetime import datetime
 from tqdm import tqdm
 import nibabel as nib
@@ -39,7 +39,7 @@ def convert(path: str, subdir: str = "PPMI"):
     task_prefix = "PPMI"
 
     subjects_dir = join(path, "DATA")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task202_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task202_ISLES22.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 import shutil
 
@@ -18,7 +18,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "images")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task202_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task202_ISLES22.py
@@ -18,7 +18,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "images")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task202_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task202_ISLES22.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 import shutil
 
@@ -18,7 +18,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "images")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task203_OASIS3.py
+++ b/yucca/pipeline/task_conversion/Task203_OASIS3.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 import nibabel as nib
 
@@ -30,7 +30,7 @@ def convert(path: str, subdir: str = "OASIS3"):
     task_prefix = "OASIS3"
 
     subjects_dir = join(path, "DATA")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task203_OASIS3.py
+++ b/yucca/pipeline/task_conversion/Task203_OASIS3.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 import nibabel as nib
 
@@ -30,7 +30,7 @@ def convert(path: str, subdir: str = "OASIS3"):
     task_prefix = "OASIS3"
 
     subjects_dir = join(path, "DATA")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task203_OASIS3.py
+++ b/yucca/pipeline/task_conversion/Task203_OASIS3.py
@@ -30,7 +30,7 @@ def convert(path: str, subdir: str = "OASIS3"):
     task_prefix = "OASIS3"
 
     subjects_dir = join(path, "DATA")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task204_OASIS4.py
+++ b/yucca/pipeline/task_conversion/Task204_OASIS4.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, should_use_volume, dirs_in_dir
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 import nibabel as nib
 
@@ -26,7 +26,7 @@ def convert(path: str, subdir: str = "OASIS4"):
     task_prefix = "OASIS4"
 
     subjects_dir = join(path, "OASIS4_images")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task204_OASIS4.py
+++ b/yucca/pipeline/task_conversion/Task204_OASIS4.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, should_use_volume, dirs_in_dir
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 import nibabel as nib
 
@@ -26,7 +26,7 @@ def convert(path: str, subdir: str = "OASIS4"):
     task_prefix = "OASIS4"
 
     subjects_dir = join(path, "OASIS4_images")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task204_OASIS4.py
+++ b/yucca/pipeline/task_conversion/Task204_OASIS4.py
@@ -26,7 +26,7 @@ def convert(path: str, subdir: str = "OASIS4"):
     task_prefix = "OASIS4"
 
     subjects_dir = join(path, "OASIS4_images")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task205_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task205_Hippocampus.py
@@ -20,7 +20,7 @@ def convert(path: str, subdir: str = "decathlon/Task04_Hippocampus"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "imagesTr")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task205_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task205_Hippocampus.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, should_use_volume
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 
 import nibabel as nib
@@ -20,7 +20,7 @@ def convert(path: str, subdir: str = "decathlon/Task04_Hippocampus"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "imagesTr")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task205_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task205_Hippocampus.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, should_use_volume
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 
 import nibabel as nib
@@ -20,7 +20,7 @@ def convert(path: str, subdir: str = "decathlon/Task04_Hippocampus"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "imagesTr")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task206_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task206_BrainTumour.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 import nibabel as nib
 
@@ -19,7 +19,7 @@ def convert(path: str, subdir: str = "decathlon/Task01_BrainTumour"):
 
     # NOTE: We use the test set for pre-training, as the labels are no longer available, and we thus cannot use it for evaluation!
     subjects_dir = join(path, "imagesTs")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task206_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task206_BrainTumour.py
@@ -19,7 +19,7 @@ def convert(path: str, subdir: str = "decathlon/Task01_BrainTumour"):
 
     # NOTE: We use the test set for pre-training, as the labels are no longer available, and we thus cannot use it for evaluation!
     subjects_dir = join(path, "imagesTs")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task206_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task206_BrainTumour.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 import nibabel as nib
 
@@ -19,7 +19,7 @@ def convert(path: str, subdir: str = "decathlon/Task01_BrainTumour"):
 
     # NOTE: We use the test set for pre-training, as the labels are no longer available, and we thus cannot use it for evaluation!
     subjects_dir = join(path, "imagesTs")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task207_ADNI.py
+++ b/yucca/pipeline/task_conversion/Task207_ADNI.py
@@ -1,7 +1,7 @@
 import gzip
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 import shutil
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "ADNI_NIFTI"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "ADNI")
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task207_ADNI.py
+++ b/yucca/pipeline/task_conversion/Task207_ADNI.py
@@ -1,7 +1,7 @@
 import gzip
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 import shutil
 
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "ADNI_NIFTI"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "ADNI")
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task207_ADNI.py
+++ b/yucca/pipeline/task_conversion/Task207_ADNI.py
@@ -24,7 +24,7 @@ def convert(path: str, subdir: str = "ADNI_NIFTI"):
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     subjects_dir = join(path, "ADNI")
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task208_WMH.py
+++ b/yucca/pipeline/task_conversion/Task208_WMH.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     # site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
 

--- a/yucca/pipeline/task_conversion/Task208_WMH.py
+++ b/yucca/pipeline/task_conversion/Task208_WMH.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "WMH"):
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     # site = ""
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
 

--- a/yucca/pipeline/task_conversion/Task208_WMH.py
+++ b/yucca/pipeline/task_conversion/Task208_WMH.py
@@ -16,7 +16,7 @@ def convert(path: str, subdir: str = "WMH"):
     # site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
 

--- a/yucca/pipeline/task_conversion/Task209_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task209_BraTS21.py
@@ -14,8 +14,8 @@ def convert(_path: str):
     sup_task_name = "Task012_BraTS21"
     ssl_task_name = "Task209_BraTS21"
 
-    source_folder = join(yucca_raw_data, sup_task_name, "imagesTr")
-    target_base = join(yucca_raw_data, ssl_task_name)
+    source_folder = join(yucca_raw_data(), sup_task_name, "imagesTr")
+    target_base = join(yucca_raw_data(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task209_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task209_BraTS21.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 import shutil
 from tqdm import tqdm
 from os.path import basename
@@ -14,8 +14,8 @@ def convert(_path: str):
     sup_task_name = "Task012_BraTS21"
     ssl_task_name = "Task209_BraTS21"
 
-    source_folder = join(yucca_raw_data(), sup_task_name, "imagesTr")
-    target_base = join(yucca_raw_data(), ssl_task_name)
+    source_folder = join(get_yucca_raw_data(), sup_task_name, "imagesTr")
+    target_base = join(get_yucca_raw_data(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task209_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task209_BraTS21.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 import shutil
 from tqdm import tqdm
 from os.path import basename
@@ -14,8 +14,8 @@ def convert(_path: str):
     sup_task_name = "Task012_BraTS21"
     ssl_task_name = "Task209_BraTS21"
 
-    source_folder = join(get_yucca_raw_data(), sup_task_name, "imagesTr")
-    target_base = join(get_yucca_raw_data(), ssl_task_name)
+    source_folder = join(get_raw_data_path(), sup_task_name, "imagesTr")
+    target_base = join(get_raw_data_path(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task210_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task210_MSSEG1.py
@@ -14,8 +14,8 @@ def convert(_path: str):
     sup_task_name = "Task011_MSSEG1"
     ssl_task_name = "Task210_MSSEG1"
 
-    source_folder = join(yucca_raw_data, sup_task_name, "imagesTr")
-    target_base = join(yucca_raw_data, ssl_task_name)
+    source_folder = join(yucca_raw_data(), sup_task_name, "imagesTr")
+    target_base = join(yucca_raw_data(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task210_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task210_MSSEG1.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 import shutil
 from tqdm import tqdm
 from os.path import basename
@@ -14,8 +14,8 @@ def convert(_path: str):
     sup_task_name = "Task011_MSSEG1"
     ssl_task_name = "Task210_MSSEG1"
 
-    source_folder = join(yucca_raw_data(), sup_task_name, "imagesTr")
-    target_base = join(yucca_raw_data(), ssl_task_name)
+    source_folder = join(get_yucca_raw_data(), sup_task_name, "imagesTr")
+    target_base = join(get_yucca_raw_data(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task210_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task210_MSSEG1.py
@@ -1,6 +1,6 @@
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 import shutil
 from tqdm import tqdm
 from os.path import basename
@@ -14,8 +14,8 @@ def convert(_path: str):
     sup_task_name = "Task011_MSSEG1"
     ssl_task_name = "Task210_MSSEG1"
 
-    source_folder = join(get_yucca_raw_data(), sup_task_name, "imagesTr")
-    target_base = join(get_yucca_raw_data(), ssl_task_name)
+    source_folder = join(get_raw_data_path(), sup_task_name, "imagesTr")
+    target_base = join(get_raw_data_path(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     maybe_mkdir_p(target_imagesTr)

--- a/yucca/pipeline/task_conversion/Task241_BR41NS.py
+++ b/yucca/pipeline/task_conversion/Task241_BR41NS.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(_path: str, _subdir: str = None):
@@ -22,7 +22,7 @@ def convert(_path: str, _subdir: str = None):
         "Task208_WMH",
     ]
 
-    target_base = os.path.join(get_yucca_raw_data(), task_name)
+    target_base = os.path.join(get_raw_data_path(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task241_BR41NS.py
+++ b/yucca/pipeline/task_conversion/Task241_BR41NS.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(_path: str, _subdir: str = None):
@@ -22,7 +22,7 @@ def convert(_path: str, _subdir: str = None):
         "Task208_WMH",
     ]
 
-    target_base = os.path.join(yucca_raw_data(), task_name)
+    target_base = os.path.join(get_yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task241_BR41NS.py
+++ b/yucca/pipeline/task_conversion/Task241_BR41NS.py
@@ -22,7 +22,7 @@ def convert(_path: str, _subdir: str = None):
         "Task208_WMH",
     ]
 
-    target_base = os.path.join(yucca_raw_data, task_name)
+    target_base = os.path.join(yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task245_BRAINS-45K.py
+++ b/yucca/pipeline/task_conversion/Task245_BRAINS-45K.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(_path: str, _subdir: str = None):
@@ -25,7 +25,7 @@ def convert(_path: str, _subdir: str = None):
         "Task210_MSSEG1",
     ]
 
-    target_base = os.path.join(yucca_raw_data(), task_name)
+    target_base = os.path.join(get_yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task245_BRAINS-45K.py
+++ b/yucca/pipeline/task_conversion/Task245_BRAINS-45K.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(_path: str, _subdir: str = None):
@@ -25,7 +25,7 @@ def convert(_path: str, _subdir: str = None):
         "Task210_MSSEG1",
     ]
 
-    target_base = os.path.join(get_yucca_raw_data(), task_name)
+    target_base = os.path.join(get_raw_data_path(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task245_BRAINS-45K.py
+++ b/yucca/pipeline/task_conversion/Task245_BRAINS-45K.py
@@ -25,7 +25,7 @@ def convert(_path: str, _subdir: str = None):
         "Task210_MSSEG1",
     ]
 
-    target_base = os.path.join(yucca_raw_data, task_name)
+    target_base = os.path.join(yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task298_Combine_supervised.py
+++ b/yucca/pipeline/task_conversion/Task298_Combine_supervised.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(_path: str, _subdir: str = None):
@@ -11,7 +11,7 @@ def convert(_path: str, _subdir: str = None):
     # The individual task_conversion scripts must be run prior to executing this, as the script will look for the data in the yucca_raw_data folder.
     tasks_to_combine = ["Task001_OASIS", "Task003_Hammers"]
 
-    target_base = os.path.join(yucca_raw_data(), task_name)
+    target_base = os.path.join(get_yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="supervised")

--- a/yucca/pipeline/task_conversion/Task298_Combine_supervised.py
+++ b/yucca/pipeline/task_conversion/Task298_Combine_supervised.py
@@ -11,7 +11,7 @@ def convert(_path: str, _subdir: str = None):
     # The individual task_conversion scripts must be run prior to executing this, as the script will look for the data in the yucca_raw_data folder.
     tasks_to_combine = ["Task001_OASIS", "Task003_Hammers"]
 
-    target_base = os.path.join(yucca_raw_data, task_name)
+    target_base = os.path.join(yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="supervised")

--- a/yucca/pipeline/task_conversion/Task298_Combine_supervised.py
+++ b/yucca/pipeline/task_conversion/Task298_Combine_supervised.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(_path: str, _subdir: str = None):
@@ -11,7 +11,7 @@ def convert(_path: str, _subdir: str = None):
     # The individual task_conversion scripts must be run prior to executing this, as the script will look for the data in the yucca_raw_data folder.
     tasks_to_combine = ["Task001_OASIS", "Task003_Hammers"]
 
-    target_base = os.path.join(get_yucca_raw_data(), task_name)
+    target_base = os.path.join(get_raw_data_path(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="supervised")

--- a/yucca/pipeline/task_conversion/Task299_Combine.py
+++ b/yucca/pipeline/task_conversion/Task299_Combine.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(_path: str, _subdir: str = None):
@@ -14,7 +14,7 @@ def convert(_path: str, _subdir: str = None):
     # The individual task_conversion scripts must be run prior to executing this, as the script will look for the data in the yucca_raw_data folder.
     tasks_to_combine = ["Task201_PPMI", "Task202_ISLES22", "Task203_OASIS3", "Task205_Hippocampus", "Task206_BrainTumour"]
 
-    target_base = os.path.join(yucca_raw_data(), task_name)
+    target_base = os.path.join(get_yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task299_Combine.py
+++ b/yucca/pipeline/task_conversion/Task299_Combine.py
@@ -14,7 +14,7 @@ def convert(_path: str, _subdir: str = None):
     # The individual task_conversion scripts must be run prior to executing this, as the script will look for the data in the yucca_raw_data folder.
     tasks_to_combine = ["Task201_PPMI", "Task202_ISLES22", "Task203_OASIS3", "Task205_Hippocampus", "Task206_BrainTumour"]
 
-    target_base = os.path.join(yucca_raw_data, task_name)
+    target_base = os.path.join(yucca_raw_data(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task299_Combine.py
+++ b/yucca/pipeline/task_conversion/Task299_Combine.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_images_from_tasks, generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(_path: str, _subdir: str = None):
@@ -14,7 +14,7 @@ def convert(_path: str, _subdir: str = None):
     # The individual task_conversion scripts must be run prior to executing this, as the script will look for the data in the yucca_raw_data folder.
     tasks_to_combine = ["Task201_PPMI", "Task202_ISLES22", "Task203_OASIS3", "Task205_Hippocampus", "Task206_BrainTumour"]
 
-    target_base = os.path.join(get_yucca_raw_data(), task_name)
+    target_base = os.path.join(get_raw_data_path(), task_name)
     os.makedirs(target_base, exist_ok=True)
 
     combine_images_from_tasks(tasks=tasks_to_combine, target_base=target_base, run_type="unsupervised")

--- a/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
+++ b/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
@@ -30,7 +30,7 @@ def convert(path: str, subdir: str = "FETAL_PLANES_DB"):
     prefix = "FetalPlanesDB"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
+++ b/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
@@ -11,7 +11,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -30,7 +30,7 @@ def convert(path: str, subdir: str = "FETAL_PLANES_DB"):
     prefix = "FetalPlanesDB"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
+++ b/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
@@ -11,7 +11,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -30,7 +30,7 @@ def convert(path: str, subdir: str = "FETAL_PLANES_DB"):
     prefix = "FetalPlanesDB"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
+++ b/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
@@ -9,7 +9,7 @@ import pandas as pd
 import shutil
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs, subfiles
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "tiny-imagenet-200"):
     prefix = "tiny_imagenet_200"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
+++ b/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "tiny-imagenet-200"):
     prefix = "tiny_imagenet_200"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
+++ b/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
@@ -9,7 +9,7 @@ import pandas as pd
 import shutil
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs, subfiles
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -28,7 +28,7 @@ def convert(path: str, subdir: str = "tiny-imagenet-200"):
     prefix = "tiny_imagenet_200"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
@@ -34,7 +34,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from tqdm import tqdm
 
 
@@ -56,7 +56,7 @@ def convert(path: str, subdir: str = "OASIS"):
     prefix = "OASIS"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
@@ -34,7 +34,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from tqdm import tqdm
 
 
@@ -56,7 +56,7 @@ def convert(path: str, subdir: str = "OASIS"):
     prefix = "OASIS"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
@@ -56,7 +56,7 @@ def convert(path: str, subdir: str = "OASIS"):
     prefix = "OASIS"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
@@ -40,7 +40,7 @@ def convert(path: str, txt_file_prefix: str = "data"):
     prefix = "SONAI"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
@@ -7,7 +7,7 @@ Task_conversion file for the SONAI data, without labels and with 2D jpg images (
 import shutil
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -40,7 +40,7 @@ def convert(path: str, txt_file_prefix: str = "data"):
     prefix = "SONAI"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
@@ -7,7 +7,7 @@ Task_conversion file for the SONAI data, without labels and with 2D jpg images (
 import shutil
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -40,7 +40,7 @@ def convert(path: str, txt_file_prefix: str = "data"):
     prefix = "SONAI"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
@@ -40,7 +40,7 @@ def convert(path: str, txt_file_prefix: str = "sonai_100k"):
     prefix = "SONAI100k"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
@@ -7,7 +7,7 @@ Task_conversion file for the SONAI data, without labels and with 2D jpg images (
 import shutil
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -40,7 +40,7 @@ def convert(path: str, txt_file_prefix: str = "sonai_100k"):
     prefix = "SONAI100k"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
@@ -7,7 +7,7 @@ Task_conversion file for the SONAI data, without labels and with 2D jpg images (
 import shutil
 from tqdm import tqdm
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
 
@@ -40,7 +40,7 @@ def convert(path: str, txt_file_prefix: str = "sonai_100k"):
     prefix = "SONAI100k"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")

--- a/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
+++ b/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
@@ -17,7 +17,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
+++ b/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 import numpy as np
 
 
@@ -17,7 +17,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
+++ b/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
@@ -1,7 +1,7 @@
 import shutil
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 import numpy as np
 
 
@@ -17,7 +17,7 @@ def convert(path: str, subdir: str = "WMH"):
     site = ""
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/template.py
+++ b/yucca/pipeline/task_conversion/template.py
@@ -15,7 +15,7 @@ def convert(path: str, subdir: str = "MyDataset"):
     task_name = "Task000_MyTask"
     task_prefix = "MyTask"
 
-    """ Access the input data. If images are not split into train/test, and you wish to randomly 
+    """ Access the input data. If images are not split into train/test, and you wish to randomly
     split the data, uncomment and adapt the following lines to fit your local path. """
 
     images_dir = join(path, "data_dir", "images")
@@ -27,7 +27,7 @@ def convert(path: str, subdir: str = "MyDataset"):
     images_dir_tr = images_dir_ts = images_dir
     labels_dir_tr = labels_dir_ts = labels_dir
 
-    """ If images are already split into train/test and images/labels uncomment and adapt the following 
+    """ If images are already split into train/test and images/labels uncomment and adapt the following
     lines to fit your local path."""
 
     # images_dir_tr = join(path, 'train_dir', 'images')
@@ -39,7 +39,7 @@ def convert(path: str, subdir: str = "MyDataset"):
     # test_samples = subfiles(labels_dir_ts, join=False, suffix=file_suffix)
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/template.py
+++ b/yucca/pipeline/task_conversion/template.py
@@ -3,7 +3,7 @@ import gzip
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 def convert(path: str, subdir: str = "MyDataset"):
@@ -39,7 +39,7 @@ def convert(path: str, subdir: str = "MyDataset"):
     # test_samples = subfiles(labels_dir_ts, join=False, suffix=file_suffix)
 
     """ Then define target paths """
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/template.py
+++ b/yucca/pipeline/task_conversion/template.py
@@ -3,7 +3,7 @@ import gzip
 from sklearn.model_selection import train_test_split
 from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 def convert(path: str, subdir: str = "MyDataset"):
@@ -39,7 +39,7 @@ def convert(path: str, subdir: str = "MyDataset"):
     # test_samples = subfiles(labels_dir_ts, join=False, suffix=file_suffix)
 
     """ Then define target paths """
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/template_combine_imagesTr.py
+++ b/yucca/pipeline/task_conversion/template_combine_imagesTr.py
@@ -18,8 +18,8 @@ tasks_to_combine = []
 
 ### In most cases the remaining can be left untouched ###
 # Setting the paths to save the new task and making the directories
-target_base = os.path.join(yucca_raw_data, task_name)
-target_imagesTr = os.path.join(yucca_raw_data, task_name, "imagesTr")
+target_base = os.path.join(yucca_raw_data(), task_name)
+target_imagesTr = os.path.join(yucca_raw_data(), task_name, "imagesTr")
 target_imagesTs = None
 os.makedirs(target_imagesTr, exist_ok=True)
 

--- a/yucca/pipeline/task_conversion/template_combine_imagesTr.py
+++ b/yucca/pipeline/task_conversion/template_combine_imagesTr.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_imagesTr_from_tasks, generate_dataset_json
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 
 
 # Define the name of the new task
@@ -18,8 +18,8 @@ tasks_to_combine = []
 
 ### In most cases the remaining can be left untouched ###
 # Setting the paths to save the new task and making the directories
-target_base = os.path.join(yucca_raw_data(), task_name)
-target_imagesTr = os.path.join(yucca_raw_data(), task_name, "imagesTr")
+target_base = os.path.join(get_yucca_raw_data(), task_name)
+target_imagesTr = os.path.join(get_yucca_raw_data(), task_name, "imagesTr")
 target_imagesTs = None
 os.makedirs(target_imagesTr, exist_ok=True)
 

--- a/yucca/pipeline/task_conversion/template_combine_imagesTr.py
+++ b/yucca/pipeline/task_conversion/template_combine_imagesTr.py
@@ -1,6 +1,6 @@
 import os
 from yucca.pipeline.task_conversion.utils import combine_imagesTr_from_tasks, generate_dataset_json
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 
 
 # Define the name of the new task
@@ -18,8 +18,8 @@ tasks_to_combine = []
 
 ### In most cases the remaining can be left untouched ###
 # Setting the paths to save the new task and making the directories
-target_base = os.path.join(get_yucca_raw_data(), task_name)
-target_imagesTr = os.path.join(get_yucca_raw_data(), task_name, "imagesTr")
+target_base = os.path.join(get_raw_data_path(), task_name)
+target_imagesTr = os.path.join(get_raw_data_path(), task_name, "imagesTr")
 target_imagesTs = None
 os.makedirs(target_imagesTr, exist_ok=True)
 

--- a/yucca/pipeline/task_conversion/template_multiprocessing.py
+++ b/yucca/pipeline/task_conversion/template_multiprocessing.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from multiprocessing import Pool
 
 
@@ -34,7 +34,7 @@ def convert(path: str, subdir: str = "DatasetName"):
     prefix = "MyTask"
 
     # Target paths
-    target_base = join(yucca_raw_data(), task_name)
+    target_base = join(get_yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/template_multiprocessing.py
+++ b/yucca/pipeline/task_conversion/template_multiprocessing.py
@@ -2,7 +2,7 @@ from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkd
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from multiprocessing import Pool
 
 
@@ -34,7 +34,7 @@ def convert(path: str, subdir: str = "DatasetName"):
     prefix = "MyTask"
 
     # Target paths
-    target_base = join(get_yucca_raw_data(), task_name)
+    target_base = join(get_raw_data_path(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/template_multiprocessing.py
+++ b/yucca/pipeline/task_conversion/template_multiprocessing.py
@@ -34,7 +34,7 @@ def convert(path: str, subdir: str = "DatasetName"):
     prefix = "MyTask"
 
     # Target paths
-    target_base = join(yucca_raw_data, task_name)
+    target_base = join(yucca_raw_data(), task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
     target_labelsTr = join(target_base, "labelsTr")

--- a/yucca/pipeline/task_conversion/utils.py
+++ b/yucca/pipeline/task_conversion/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import shutil
 import nibabel as nib
-from yucca.paths import get_yucca_raw_data
+from yucca.paths import get_raw_data_path
 from typing import Literal
 from batchgenerators.utilities.file_and_folder_operations import save_json, subfiles, join, subdirs
 from tqdm import tqdm
@@ -14,7 +14,7 @@ def combine_images_from_tasks(tasks: list, target_base: str, run_type: Literal["
     for task in tqdm(tasks):
         folders = ["imagesTr", "imagesTs", "labelsTr", "labelsTs"] if run_type == "supervised" else ["imagesTr"]
         for folder in folders:
-            source = os.path.join(get_yucca_raw_data(), task, folder)
+            source = os.path.join(get_raw_data_path(), task, folder)
             target = os.path.join(target_base, folder)
             print("Copying ", source, target)
             copy_files_from_to(source, target)
@@ -128,7 +128,7 @@ def generate_dataset_json(
 
 def maybe_get_task_from_task_id(task_id: str | int):
     task_id = str(task_id)
-    tasks = subdirs(get_yucca_raw_data(), join=False)
+    tasks = subdirs(get_raw_data_path(), join=False)
 
     # Check if name is already complete
     if task_id in tasks:
@@ -142,6 +142,6 @@ def maybe_get_task_from_task_id(task_id: str | int):
 
     # If we can't find anything we just return the original, on the offchance that the task does not exist in Raw Data while existing in e.g. Preprocessed
     print(
-        f"Couldn't find a task called: {task_id} in the raw data folder: {get_yucca_raw_data()}. If your task only exists in e.g. the Preprocessed folder things might still work."
+        f"Couldn't find a task called: {task_id} in the raw data folder: {get_raw_data_path()}. If your task only exists in e.g. the Preprocessed folder things might still work."
     )
     return task_id

--- a/yucca/pipeline/task_conversion/utils.py
+++ b/yucca/pipeline/task_conversion/utils.py
@@ -14,7 +14,7 @@ def combine_images_from_tasks(tasks: list, target_base: str, run_type: Literal["
     for task in tqdm(tasks):
         folders = ["imagesTr", "imagesTs", "labelsTr", "labelsTs"] if run_type == "supervised" else ["imagesTr"]
         for folder in folders:
-            source = os.path.join(yucca_raw_data, task, folder)
+            source = os.path.join(yucca_raw_data(), task, folder)
             target = os.path.join(target_base, folder)
             print("Copying ", source, target)
             copy_files_from_to(source, target)
@@ -128,7 +128,7 @@ def generate_dataset_json(
 
 def maybe_get_task_from_task_id(task_id: str | int):
     task_id = str(task_id)
-    tasks = subdirs(yucca_raw_data, join=False)
+    tasks = subdirs(yucca_raw_data(), join=False)
 
     # Check if name is already complete
     if task_id in tasks:
@@ -142,6 +142,6 @@ def maybe_get_task_from_task_id(task_id: str | int):
 
     # If we can't find anything we just return the original, on the offchance that the task does not exist in Raw Data while existing in e.g. Preprocessed
     print(
-        f"Couldn't find a task called: {task_id} in the raw data folder: {yucca_raw_data}. If your task only exists in e.g. the Preprocessed folder things might still work."
+        f"Couldn't find a task called: {task_id} in the raw data folder: {yucca_raw_data()}. If your task only exists in e.g. the Preprocessed folder things might still work."
     )
     return task_id

--- a/yucca/pipeline/task_conversion/utils.py
+++ b/yucca/pipeline/task_conversion/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import shutil
 import nibabel as nib
-from yucca.paths import yucca_raw_data
+from yucca.paths import get_yucca_raw_data
 from typing import Literal
 from batchgenerators.utilities.file_and_folder_operations import save_json, subfiles, join, subdirs
 from tqdm import tqdm
@@ -14,7 +14,7 @@ def combine_images_from_tasks(tasks: list, target_base: str, run_type: Literal["
     for task in tqdm(tasks):
         folders = ["imagesTr", "imagesTs", "labelsTr", "labelsTs"] if run_type == "supervised" else ["imagesTr"]
         for folder in folders:
-            source = os.path.join(yucca_raw_data(), task, folder)
+            source = os.path.join(get_yucca_raw_data(), task, folder)
             target = os.path.join(target_base, folder)
             print("Copying ", source, target)
             copy_files_from_to(source, target)
@@ -128,7 +128,7 @@ def generate_dataset_json(
 
 def maybe_get_task_from_task_id(task_id: str | int):
     task_id = str(task_id)
-    tasks = subdirs(yucca_raw_data(), join=False)
+    tasks = subdirs(get_yucca_raw_data(), join=False)
 
     # Check if name is already complete
     if task_id in tasks:
@@ -142,6 +142,6 @@ def maybe_get_task_from_task_id(task_id: str | int):
 
     # If we can't find anything we just return the original, on the offchance that the task does not exist in Raw Data while existing in e.g. Preprocessed
     print(
-        f"Couldn't find a task called: {task_id} in the raw data folder: {yucca_raw_data()}. If your task only exists in e.g. the Preprocessed folder things might still work."
+        f"Couldn't find a task called: {task_id} in the raw data folder: {get_yucca_raw_data()}. If your task only exists in e.g. the Preprocessed folder things might still work."
     )
     return task_id


### PR DESCRIPTION
In general i think that Yucca Functional should be completely agnostic to the underlying folder structure. However, while this will take some more work, this PR changes the handling of path environtment vars such that they are fetched just-in-time, and when actually needed we throw an exception if it is not set instead of a warning.