### PR TITLE
No more maybe

### DIFF
--- a/yucca/documentation/templates/functional_inference.py
+++ b/yucca/documentation/templates/functional_inference.py
@@ -2,7 +2,7 @@ if __name__ == "__main__":
     import lightning as L
     import os
     import torch
-    from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p
+    from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p as ensure_dir_exists
     from yucca.paths import (
         get_models_path,
         get_results_path,
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         "version_0",
         "best",
     )
-    maybe_mkdir_p(save_path)
+    ensure_dir_exists(save_path)
 
     ckpt = torch.load(ckpt_path, map_location="cpu")
     config = ckpt["hyper_parameters"]["config"]

--- a/yucca/documentation/templates/functional_preprocessing.py
+++ b/yucca/documentation/templates/functional_preprocessing.py
@@ -4,7 +4,13 @@ if __name__ == "__main__":
     import os
     import numpy as np
     import torch
-    from batchgenerators.utilities.file_and_folder_operations import subfiles, join, save_pickle, maybe_mkdir_p, save_json
+    from batchgenerators.utilities.file_and_folder_operations import (
+        subfiles,
+        join,
+        save_pickle,
+        maybe_mkdir_p as ensure_dir_exists,
+        save_json,
+    )
     from yucca.paths import get_raw_data_path, get_preprocessed_data_path
     from yucca.documentation.templates.template_config import config
     from yucca.functional.preprocessing import preprocess_case_for_training_with_label, preprocess_case_for_inference
@@ -18,8 +24,8 @@ if __name__ == "__main__":
     target_dir = join(get_preprocessed_data_path(), config["task"], config["plans_name"])
     test_target_dir = join(get_preprocessed_data_path(), config["task"] + "_test", config["plans_name"])
 
-    maybe_mkdir_p(target_dir)
-    maybe_mkdir_p(test_target_dir)
+    ensure_dir_exists(target_dir)
+    ensure_dir_exists(test_target_dir)
 
     plans = make_plans_file(
         allow_missing_modalities=False,

--- a/yucca/functional/utils/__init__.py
+++ b/yucca/functional/utils/__init__.py
@@ -17,5 +17,5 @@ from .saving import (
     save_txt_from_numpy,
 )
 from .softmax import softmax
-from .torch_utils import maybe_to_gpu, get_available_device, flush_and_get_torch_memory_allocated, measure_FLOPs
+from .torch_utils import move_to_available_device, get_available_device, flush_and_get_torch_memory_allocated, measure_FLOPs
 from .type_conversions import np_to_nifti_with_empty_header, nifti_or_np_to_np, png_to_nifti

--- a/yucca/functional/utils/saving.py
+++ b/yucca/functional/utils/saving.py
@@ -6,7 +6,7 @@ from PIL import Image
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
     subfiles,
-    maybe_mkdir_p,
+    maybe_mkdir_p as ensure_dir_exists,
 )
 
 
@@ -54,7 +54,7 @@ def save_prediction_from_logits(logits, outpath, properties, save_softmax=False,
 
 
 def merge_softmax_from_folders(folders: list, outpath, method="sum"):
-    maybe_mkdir_p(outpath)
+    ensure_dir_exists(outpath)
     cases = subfiles(folders[0], suffix=".npz", join=False)
     for folder in folders:
         assert cases == subfiles(folder, suffix=".npz", join=False), (

--- a/yucca/functional/utils/torch_utils.py
+++ b/yucca/functional/utils/torch_utils.py
@@ -2,7 +2,7 @@ import torch
 from fvcore.nn import FlopCountAnalysis
 
 
-def maybe_to_gpu(data):
+def move_to_available_device(data):
     device = get_available_device()
 
     if isinstance(data, list):

--- a/yucca/modules/callbacks/loggers.py
+++ b/yucca/modules/callbacks/loggers.py
@@ -9,7 +9,7 @@ from lightning_fabric.utilities.logger import _convert_params
 from time import localtime, strftime, time
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
-    maybe_mkdir_p,
+    maybe_mkdir_p as ensure_dir_exists,
     isdir,
 )
 from typing import Any, Dict, Optional, Union
@@ -64,12 +64,12 @@ class YuccaLogger(Logger):
             version = self.version if isinstance(self.version, str) else f"version_{self.version}"
             log_dir = join(log_dir, version)
         if not isdir(log_dir):
-            maybe_mkdir_p(log_dir)
+            ensure_dir_exists(log_dir)
         return log_dir
 
     @rank_zero_only
     def create_logfile(self):
-        maybe_mkdir_p(self.log_dir)
+        ensure_dir_exists(self.log_dir)
         self.log_file = join(
             self.log_dir,
             "training_log.txt",

--- a/yucca/paths.py
+++ b/yucca/paths.py
@@ -5,7 +5,7 @@ PLEASE READ YUCCA/DOCUMENTATION/TUTORIALS/ENVIRONMENT_VARIABLES.MD FOR INFORMATI
 import os
 from dotenv import load_dotenv
 
-from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p as ensure_dir_exists as ensure_dir_exists
+from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p as ensure_dir_exists
 
 
 def var_is_set(var):

--- a/yucca/paths.py
+++ b/yucca/paths.py
@@ -5,7 +5,7 @@ PLEASE READ YUCCA/DOCUMENTATION/TUTORIALS/ENVIRONMENT_VARIABLES.MD FOR INFORMATI
 import os
 from dotenv import load_dotenv
 
-from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p as ensure_dir_exists
+from batchgenerators.utilities.file_and_folder_operations import maybe_mkdir_p as ensure_dir_exists as ensure_dir_exists
 
 
 def var_is_set(var):

--- a/yucca/pipeline/configuration/configure_paths.py
+++ b/yucca/pipeline/configuration/configure_paths.py
@@ -38,7 +38,7 @@ def get_path_config(task_config: TaskConfig):
 
     version = detect_version(save_dir, task_config.continue_from_most_recent)
     version_dir = join(save_dir, f"version_{version}")
-    maybe_mkdir_p(version_dir)
+    ensure_dir_exists(version_dir)
     plans_path = join(task_dir, task_config.planner_name, task_config.planner_name + "_plans.json")
 
     return PathConfig(

--- a/yucca/pipeline/configuration/configure_paths.py
+++ b/yucca/pipeline/configuration/configure_paths.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, isdir, subdirs, maybe_mkdir_p
+from batchgenerators.utilities.file_and_folder_operations import join, isdir, subdirs, maybe_mkdir_p as ensure_dir_exists
 from dataclasses import dataclass
 from typing import Union
 from yucca.paths import get_models_path, get_preprocessed_data_path

--- a/yucca/pipeline/evaluation/challenge_preparation_scripts/prepare_decathlon.py
+++ b/yucca/pipeline/evaluation/challenge_preparation_scripts/prepare_decathlon.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import subfiles, join, maybe_mkdir_p
+from batchgenerators.utilities.file_and_folder_operations import subfiles, join, maybe_mkdir_p as ensure_dir_exists
 import shutil
 
 """
@@ -68,7 +68,7 @@ blacklist = [
 ]
 
 savepath = "/home/zcr545/decathlon_submission"
-maybe_mkdir_p(savepath)
+ensure_dir_exists(savepath)
 
 for i in range(10):
     for seg_path in subfiles(folders[i], join=False):
@@ -77,6 +77,6 @@ for i in range(10):
         if new_path in blacklist:
             print("blocking: ", new_path)
             continue
-        maybe_mkdir_p(join(savepath, expected[i]))
+        ensure_dir_exists(join(savepath, expected[i]))
 
         shutil.copy(join(folders[i], seg_path), f"{savepath}/{expected[i]}/{new_filename}")

--- a/yucca/pipeline/planning/YuccaPlanner.py
+++ b/yucca/pipeline/planning/YuccaPlanner.py
@@ -4,7 +4,13 @@ import numpy as np
 from yucca.paths import get_preprocessed_data_path, get_raw_data_path
 from yucca.pipeline.planning.dataset_properties import create_dataset_properties
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, isfile, load_pickle, save_json
+from batchgenerators.utilities.file_and_folder_operations import (
+    join,
+    maybe_mkdir_p as ensure_dir_exists,
+    isfile,
+    load_pickle,
+    save_json,
+)
 from yucca.functional.planning import make_plans_file, add_stats_to_plans_post_preprocessing
 from yucca.pipeline.preprocessing import UnsupervisedPreprocessor
 
@@ -187,7 +193,7 @@ class YuccaPlanner(object):
         self.target_dir = join(get_preprocessed_data_path(), self.task)
         self.plans_folder = join(self.target_dir, self.name)
         self.plans_path = join(self.plans_folder, self.name + "_plans.json")
-        maybe_mkdir_p(join(self.target_dir, self.name))
+        ensure_dir_exists(join(self.target_dir, self.name))
 
     def determine_task_type(self):
         preprocessor_class = recursive_find_python_class(

--- a/yucca/pipeline/preprocessing/YuccaPreprocessor.py
+++ b/yucca/pipeline/preprocessing/YuccaPreprocessor.py
@@ -24,7 +24,7 @@ from batchgenerators.utilities.file_and_folder_operations import (
     load_json,
     subfiles,
     save_pickle,
-    maybe_mkdir_p,
+    maybe_mkdir_p as ensure_dir_exists,
     isfile,
 )
 
@@ -124,7 +124,7 @@ class YuccaPreprocessor(object):
     def run(self):
         self.initialize_properties()
         self.initialize_paths()
-        maybe_mkdir_p(self.target_dir)
+        ensure_dir_exists(self.target_dir)
         self.verify_compression_level(self.target_dir, self.compress)
 
         logging.info(

--- a/yucca/pipeline/run/run_evaluation.py
+++ b/yucca/pipeline/run/run_evaluation.py
@@ -11,7 +11,7 @@ from the same task as the one the model is trained on.
 import argparse
 from batchgenerators.utilities.file_and_folder_operations import load_json, join
 from yucca.pipeline.evaluation.YuccaEvaluator import YuccaEvaluator
-from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
+from yucca.pipeline.task_conversion.utils import get_task_from_task_id
 from yucca.paths import get_raw_data_path, get_results_path
 
 
@@ -90,8 +90,8 @@ def main():
     )
     args = parser.parse_args()
 
-    source_task = maybe_get_task_from_task_id(args.s)
-    target_task = maybe_get_task_from_task_id(args.t)
+    source_task = get_task_from_task_id(args.s, stage="raw")
+    target_task = get_task_from_task_id(args.t, stage="raw")
     manager_name = args.man
     model = args.m
     dimensions = args.d

--- a/yucca/pipeline/run/run_finetune.py
+++ b/yucca/pipeline/run/run_finetune.py
@@ -1,6 +1,6 @@
 import argparse
 import yucca
-from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
+from yucca.pipeline.task_conversion.utils import get_task_from_task_id
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join
 
@@ -101,7 +101,7 @@ def main():
 
     args = parser.parse_args()
 
-    task = maybe_get_task_from_task_id(args.task)
+    task = get_task_from_task_id(args.task, stage="preprocessed")
     checkpoint = args.checkpoint
     dimensions = args.d
     model_name = args.m

--- a/yucca/pipeline/run/run_inference.py
+++ b/yucca/pipeline/run/run_inference.py
@@ -147,7 +147,7 @@ def main():
     args = parser.parse_args()
 
     # Required
-    source_task = get_task_from_task_id(args.s, stage="preprocessed")
+    source_task = get_task_from_task_id(args.s, stage="models")
     target_task = get_task_from_task_id(args.t, stage="raw")
 
     # Optionals (frequently changed)

--- a/yucca/pipeline/run/run_inference.py
+++ b/yucca/pipeline/run/run_inference.py
@@ -13,7 +13,7 @@ from yucca.functional.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import (
     join,
     isfile,
-    maybe_mkdir_p,
+    maybe_mkdir_p as ensure_dir_exists,
     isdir,
     subdirs,
     load_pickle,
@@ -264,7 +264,7 @@ def main():
         split = split[str(split_data_method)][split_data_param][split_idx]["val"]
         strict = False
 
-    maybe_mkdir_p(outpath)
+    ensure_dir_exists(outpath)
 
     manager.predict_folder(
         inpath,

--- a/yucca/pipeline/run/run_inference.py
+++ b/yucca/pipeline/run/run_inference.py
@@ -1,6 +1,6 @@
 import argparse
 import yucca
-from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
+from yucca.pipeline.task_conversion.utils import get_task_from_task_id
 from yucca.paths import (
     get_raw_data_path,
     get_results_path,
@@ -147,8 +147,8 @@ def main():
     args = parser.parse_args()
 
     # Required
-    source_task = maybe_get_task_from_task_id(args.s)
-    target_task = maybe_get_task_from_task_id(args.t)
+    source_task = get_task_from_task_id(args.s, stage="preprocessed")
+    target_task = get_task_from_task_id(args.t, stage="raw")
 
     # Optionals (frequently changed)
     checkpoint = args.checkpoint

--- a/yucca/pipeline/run/run_preprocessing.py
+++ b/yucca/pipeline/run/run_preprocessing.py
@@ -1,6 +1,6 @@
 import argparse
 import yucca
-from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
+from yucca.pipeline.task_conversion.utils import get_task_from_task_id
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join
 
@@ -35,7 +35,7 @@ def main():
     parser.add_argument("--threads", help="Used to specify the number of processes to use for preprocessing", default=2)
     args = parser.parse_args()
 
-    task = maybe_get_task_from_task_id(args.task)
+    task = get_task_from_task_id(args.task, stage="raw")
     planner_name = args.pl
     preprocessor_name = args.pr
     view = args.v

--- a/yucca/pipeline/run/run_training.py
+++ b/yucca/pipeline/run/run_training.py
@@ -1,6 +1,6 @@
 import argparse
 import yucca
-from yucca.pipeline.task_conversion.utils import maybe_get_task_from_task_id
+from yucca.pipeline.task_conversion.utils import get_task_from_task_id
 from yucca.functional.utils.files_and_folders import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join
 
@@ -102,7 +102,7 @@ def main():
     args = parser.parse_args()
 
     # Required
-    task = maybe_get_task_from_task_id(args.task)
+    task = get_task_from_task_id(args.task, stage="preprocessed")
 
     # Optionals (frequently changed)
     dimensions = args.d

--- a/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_CLASSIFICATION.py
@@ -1,5 +1,5 @@
 # ONLY used to run tests
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 from yucca.paths import get_raw_data_path
@@ -35,10 +35,10 @@ def convert(path: str, subdir: str = "dataset_test0_classification"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     for sTr in tqdm(training_samples, desc="Train"):
         sTr = sTr[: -len(label_suffix)]

--- a/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_SEGMENTATION.py
@@ -12,7 +12,7 @@ for i in range(7):
 
 """
 
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 from yucca.paths import get_raw_data_path, get_source_path
@@ -45,10 +45,10 @@ def convert(path: str = get_source_path(), subdir: str = "dataset_test0"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     for sTr in tqdm(training_samples, desc="Train"):
         sTr = sTr[: -len(suffix)]

--- a/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
+++ b/yucca/pipeline/task_conversion/Task000_TEST_UNSUPERVISED.py
@@ -12,7 +12,7 @@ for i in range(7):
 
 """
 
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 from yucca.paths import get_raw_data_path
@@ -43,8 +43,8 @@ def convert(path: str, subdir: str = "dataset_test0"):
 
     target_imagesTs = join(target_base, "imagesTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_imagesTs)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_imagesTs)
 
     for sTr in tqdm(training_samples, desc="Train"):
         sTr = sTr[: -len(suffix)]

--- a/yucca/pipeline/task_conversion/Task001_OASIS.py
+++ b/yucca/pipeline/task_conversion/Task001_OASIS.py
@@ -24,13 +24,13 @@ Task_conversion file for a dataset with 1 modality.
 
   It should be saved in the yucca_preprocessing_dir:
 
-    from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, save_pickle
+    from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, save_pickle
 
-    maybe_mkdir_p(join(yucca_preprocessing_dir, task_name))
+    ensure_dir_exists(join(yucca_preprocessing_dir, task_name))
     save_pickle(splits, join(yucca_preprocessing_dir, task_name, 'splits.pkl'))
 """
 
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
@@ -66,10 +66,10 @@ def convert(path: str, subdir: str = "OASIS"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task002_LPBA40.py
+++ b/yucca/pipeline/task_conversion/Task002_LPBA40.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
@@ -37,10 +37,10 @@ def convert(path: str, subdir: str = "LPBA40"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task003_Hammers.py
+++ b/yucca/pipeline/task_conversion/Task003_Hammers.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
@@ -43,10 +43,10 @@ def convert(path: str, subdir: str = "Hammers"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # Populate Target Directory
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task004_HarP.py
+++ b/yucca/pipeline/task_conversion/Task004_HarP.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
@@ -36,10 +36,10 @@ def convert(path: str, subdir: str = "HarP"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task005_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task005_ISLES22.py
@@ -1,7 +1,7 @@
 import nibabel as nib
 import nibabel.processing as nibpro
 from tqdm import tqdm
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -32,10 +32,10 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
+++ b/yucca/pipeline/task_conversion/Task006_WMH_Flair.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 
@@ -24,10 +24,10 @@ def convert(path: str, subdir: str = "WMH"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     for dataset in datasets:

--- a/yucca/pipeline/task_conversion/Task007_WMH_T1.py
+++ b/yucca/pipeline/task_conversion/Task007_WMH_T1.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 
@@ -24,10 +24,10 @@ def convert(path: str, subdir: str = "WMH"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     for dataset in datasets:

--- a/yucca/pipeline/task_conversion/Task008_WMH.py
+++ b/yucca/pipeline/task_conversion/Task008_WMH.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 
@@ -24,10 +24,10 @@ def convert(path: str, subdir: str = "WMH"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     for dataset in datasets:

--- a/yucca/pipeline/task_conversion/Task010_AMOS22.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 from yucca.paths import get_raw_data_path
@@ -33,10 +33,10 @@ def convert(path: str, subdir: str = "amos22"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
+++ b/yucca/pipeline/task_conversion/Task010_AMOS22TEST.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 from yucca.paths import get_raw_data_path
@@ -35,9 +35,9 @@ def convert(path: str, subdir: str = "amos22"):
 
     target_imagesTs = join(target_base, "imagesTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTr)
-    maybe_mkdir_p(target_imagesTs)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTr)
+    ensure_dir_exists(target_imagesTs)
 
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.
     for sTr in training_samples:

--- a/yucca/pipeline/task_conversion/Task011_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task011_MSSEG1.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 import shutil
@@ -19,10 +19,10 @@ def convert(path: str, subdir: str = "MSSEG1_2016"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # MSSEG 2016
     # INPUT DATA

--- a/yucca/pipeline/task_conversion/Task012_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task012_BraTS21.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -22,10 +22,10 @@ def convert(path: str, subdir: str = "brats21/training_data"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # INPUT DATA
     # Input path and names

--- a/yucca/pipeline/task_conversion/Task013_AutoPET3.py
+++ b/yucca/pipeline/task_conversion/Task013_AutoPET3.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.task_conversion.utils import generate_dataset_json, remove_punctuation_and_spaces
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -23,10 +23,10 @@ def convert(path: str, subdir: str = "Autopet"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # Input paths
     images_dir = join(path, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task014_MBAS24.py
+++ b/yucca/pipeline/task_conversion/Task014_MBAS24.py
@@ -1,6 +1,6 @@
 import shutil
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -27,10 +27,10 @@ def convert(path: str = get_source_path(), subdir: str = "MBAS_Dataset"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     for sTr in training_samples:
         src_image_file_path = join(images_dir, sTr, sTr + "_gt.nii.gz")

--- a/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
+++ b/yucca/pipeline/task_conversion/Task015_AIMS-TBI24.py
@@ -1,7 +1,7 @@
 import shutil
 import nibabel as nib
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -29,10 +29,10 @@ def convert(path: str = get_source_path(), subdir: str = "AIMS-TBI24"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     for sTr in training_samples:
         src_image_file_path = join(images_dir, sTr + "_T1.nii.gz")

--- a/yucca/pipeline/task_conversion/Task016_ACDC.py
+++ b/yucca/pipeline/task_conversion/Task016_ACDC.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -31,10 +31,10 @@ def convert(path: str = get_source_path(), subdir: str = "ACDC"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task017_BTCV.py
+++ b/yucca/pipeline/task_conversion/Task017_BTCV.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -29,10 +29,10 @@ def convert(path: str = get_source_path(), subdir: str = "BTCV_Abdomen"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task018_KITS23.py
+++ b/yucca/pipeline/task_conversion/Task018_KITS23.py
@@ -1,5 +1,5 @@
 import nibabel as nib
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 from yucca.functional.utils.nib_utils import reorient_to_RAS
@@ -28,10 +28,10 @@ def convert(path: str = get_source_path(), subdir: str = "kits23"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task019_LITS.py
+++ b/yucca/pipeline/task_conversion/Task019_LITS.py
@@ -1,6 +1,6 @@
 import shutil
 import gzip
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -28,10 +28,10 @@ def convert(path: str = get_source_path(), subdir: str = "LITS"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task020_ATLAS2.py
+++ b/yucca/pipeline/task_conversion/Task020_ATLAS2.py
@@ -1,6 +1,6 @@
 import shutil
 import nibabel as nib
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -29,10 +29,10 @@ def convert(path: str = get_source_path(), subdir: str = "ATLAS_2"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task021_Decathlon_BrainTumour.py
@@ -1,7 +1,7 @@
 import nibabel as nib
 import numpy as np
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
@@ -32,10 +32,10 @@ def convert(path: str = get_source_path(), subdir: str = "decathlon", subsubdir:
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     images_dir_tr = images_dir_ts = images_dir
     labels_dir_tr = labels_dir_ts = labels_dir

--- a/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
+++ b/yucca/pipeline/task_conversion/Task022_Decathlon_Heart.py
@@ -1,7 +1,7 @@
 import nibabel as nib
 import shutil
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -24,10 +24,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
+++ b/yucca/pipeline/task_conversion/Task023_Decathlon_Liver.py
@@ -1,7 +1,7 @@
 import nibabel as nib
 import numpy as np
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
@@ -32,10 +32,10 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task03_Liver
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     images_dir_tr = images_dir_ts = images_dir
     labels_dir_tr = labels_dir_ts = labels_dir

--- a/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task028_Decathlon_HepaticVessel.py
@@ -1,7 +1,7 @@
 import nibabel as nib
 import numpy as np
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.utils.nib_utils import get_nib_orientation, get_nib_spacing
@@ -32,10 +32,10 @@ def convert(path: str, subdir: str = "decathlon", subsubdir: str = "Task08_Hepat
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     images_dir_tr = images_dir_ts = images_dir
     labels_dir_tr = labels_dir_ts = labels_dir

--- a/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task031_MSD_BrainTumour.py
@@ -1,5 +1,5 @@
 import nibabel as nib
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path, get_source_path
 
@@ -28,10 +28,10 @@ def convert(path: str = get_source_path(), subdir: str = "decathlon", subsubdir:
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     for sTr in subfiles(labels_dir_tr, join=False):
         image = nib.load(join(images_dir_tr, sTr))

--- a/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
+++ b/yucca/pipeline/task_conversion/Task032_MSD_Heart.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
+++ b/yucca/pipeline/task_conversion/Task033_MSD_Liver.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task034_MSD_Hippocampus.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
+++ b/yucca/pipeline/task_conversion/Task035_MSD_Prostate.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
+++ b/yucca/pipeline/task_conversion/Task036_MSD_Lung.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
+++ b/yucca/pipeline/task_conversion/Task037_MSD_Pancreas.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
+++ b/yucca/pipeline/task_conversion/Task038_MSD_HepaticVessel.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
+++ b/yucca/pipeline/task_conversion/Task039_MSD_Spleen.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
+++ b/yucca/pipeline/task_conversion/Task040_BraTS21_flair.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -23,10 +23,10 @@ def convert(path: str, subdir: str = "brats21/training_data"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # INPUT DATA
     # Input path and names

--- a/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
+++ b/yucca/pipeline/task_conversion/Task040_MSD_Colon.py
@@ -1,6 +1,6 @@
 import nibabel as nib
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from yucca.functional.testing.data.nifti import verify_spacing_is_equal, verify_orientation_is_equal
@@ -23,10 +23,10 @@ target_labelsTr = join(target_base, "labelsTr")
 target_imagesTs = join(target_base, "imagesTs")
 target_labelsTs = join(target_base, "labelsTs")
 
-maybe_mkdir_p(target_imagesTr)
-maybe_mkdir_p(target_labelsTs)
-maybe_mkdir_p(target_imagesTs)
-maybe_mkdir_p(target_labelsTr)
+ensure_dir_exists(target_imagesTr)
+ensure_dir_exists(target_labelsTs)
+ensure_dir_exists(target_imagesTs)
+ensure_dir_exists(target_labelsTr)
 
 # Split data
 images_dir_tr = join(folder_with_images, "imagesTr")

--- a/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
+++ b/yucca/pipeline/task_conversion/Task041_BraTS21_t1.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -23,10 +23,10 @@ def convert(path: str, subdir: str = "brats21/training_data"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # INPUT DATA
     # Input path and names

--- a/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
+++ b/yucca/pipeline/task_conversion/Task042_BraTS21_t1ce.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -23,10 +23,10 @@ def convert(path: str, subdir: str = "brats21/training_data"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # INPUT DATA
     # Input path and names

--- a/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
+++ b/yucca/pipeline/task_conversion/Task043_BraTS21_t2.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from sklearn.model_selection import train_test_split
@@ -23,10 +23,10 @@ def convert(path: str, subdir: str = "brats21/training_data"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # INPUT DATA
     # Input path and names

--- a/yucca/pipeline/task_conversion/Task201_PPMI.py
+++ b/yucca/pipeline/task_conversion/Task201_PPMI.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
 from yucca.paths import get_raw_data_path
 from datetime import datetime
@@ -42,7 +42,7 @@ def convert(path: str, subdir: str = "PPMI"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     for subject in tqdm(dirs_in_dir(subjects_dir), desc="Subject"):
         subject_dir = join(subjects_dir, subject)

--- a/yucca/pipeline/task_conversion/Task202_ISLES22.py
+++ b/yucca/pipeline/task_conversion/Task202_ISLES22.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir
 from yucca.paths import get_raw_data_path
 from tqdm import tqdm
@@ -21,7 +21,7 @@ def convert(path: str, subdir: str = "ISLES-2022"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task203_OASIS3.py
+++ b/yucca/pipeline/task_conversion/Task203_OASIS3.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
 from yucca.paths import get_raw_data_path
 from tqdm import tqdm
@@ -33,7 +33,7 @@ def convert(path: str, subdir: str = "OASIS3"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     """Populate Target Directory"""
 

--- a/yucca/pipeline/task_conversion/Task204_OASIS4.py
+++ b/yucca/pipeline/task_conversion/Task204_OASIS4.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, should_use_volume, dirs_in_dir
 from yucca.paths import get_raw_data_path
 from tqdm import tqdm
@@ -29,7 +29,7 @@ def convert(path: str, subdir: str = "OASIS4"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     """Populate Target Directory"""
 

--- a/yucca/pipeline/task_conversion/Task205_Hippocampus.py
+++ b/yucca/pipeline/task_conversion/Task205_Hippocampus.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, should_use_volume
 from yucca.paths import get_raw_data_path
 from tqdm import tqdm
@@ -23,7 +23,7 @@ def convert(path: str, subdir: str = "decathlon/Task04_Hippocampus"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task206_BrainTumour.py
+++ b/yucca/pipeline/task_conversion/Task206_BrainTumour.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 from tqdm import tqdm
@@ -22,7 +22,7 @@ def convert(path: str, subdir: str = "decathlon/Task01_BrainTumour"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task207_ADNI.py
+++ b/yucca/pipeline/task_conversion/Task207_ADNI.py
@@ -1,5 +1,5 @@
 import gzip
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json, dirs_in_dir, should_use_volume
 from yucca.paths import get_raw_data_path
 from tqdm import tqdm
@@ -27,7 +27,7 @@ def convert(path: str, subdir: str = "ADNI_NIFTI"):
     target_base = join(get_raw_data_path(), task_name)
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/Task208_WMH.py
+++ b/yucca/pipeline/task_conversion/Task208_WMH.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 
@@ -20,7 +20,7 @@ def convert(path: str, subdir: str = "WMH"):
 
     target_imagesTr = join(target_base, "imagesTr")
 
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     ###Populate Target Directory###
     for dataset in datasets:

--- a/yucca/pipeline/task_conversion/Task209_BraTS21.py
+++ b/yucca/pipeline/task_conversion/Task209_BraTS21.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 import shutil
@@ -18,7 +18,7 @@ def convert(_path: str):
     target_base = join(get_raw_data_path(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     suffix = ".nii.gz"
     training_samples = subfiles(source_folder, suffix=suffix)

--- a/yucca/pipeline/task_conversion/Task210_MSSEG1.py
+++ b/yucca/pipeline/task_conversion/Task210_MSSEG1.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 import shutil
@@ -18,7 +18,7 @@ def convert(_path: str):
     target_base = join(get_raw_data_path(), ssl_task_name)
 
     target_imagesTr = join(target_base, "imagesTr")
-    maybe_mkdir_p(target_imagesTr)
+    ensure_dir_exists(target_imagesTr)
 
     suffix = ".nii.gz"
     training_samples = subfiles(source_folder, suffix=suffix)

--- a/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
+++ b/yucca/pipeline/task_conversion/Task501_FetalPlanesDB.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists
 from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
@@ -38,10 +38,10 @@ def convert(path: str, subdir: str = "FETAL_PLANES_DB"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # collect labels
     data_df = pd.read_csv(join(path, "FETAL_PLANES_DB_data.csv"), delimiter=";")

--- a/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
+++ b/yucca/pipeline/task_conversion/Task502_tiny_imagenet_200.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import shutil
 from tqdm import tqdm
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subdirs, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subdirs, subfiles
 from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
@@ -36,10 +36,10 @@ def convert(path: str, subdir: str = "tiny-imagenet-200"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     # collect labels
     next_label = 1

--- a/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task701_OASIS_NoLabel.py
@@ -24,13 +24,13 @@ Task_conversion file for a dataset with 1 modality.
 
   It should be saved in the yucca_preprocessing_dir:
 
-    from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, save_pickle
+    from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, save_pickle
 
-    maybe_mkdir_p(join(yucca_preprocessing_dir, task_name))
+    ensure_dir_exists(join(yucca_preprocessing_dir, task_name))
     save_pickle(splits, join(yucca_preprocessing_dir, task_name, 'splits.pkl'))
 """
 
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
@@ -64,10 +64,10 @@ def convert(path: str, subdir: str = "OASIS"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task901_SONAI_NoLabel.py
@@ -6,7 +6,7 @@ Task_conversion file for the SONAI data, without labels and with 2D jpg images (
 
 import shutil
 from tqdm import tqdm
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists
 from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
@@ -45,8 +45,8 @@ def convert(path: str, txt_file_prefix: str = "data"):
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_imagesTs)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_imagesTs)
 
     # Populate Target Directory
 

--- a/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
+++ b/yucca/pipeline/task_conversion/Task902_SONAI100k_NoLabel.py
@@ -6,7 +6,7 @@ Task_conversion file for the SONAI data, without labels and with 2D jpg images (
 
 import shutil
 from tqdm import tqdm
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists
 from yucca.paths import get_raw_data_path
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 
@@ -45,8 +45,8 @@ def convert(path: str, txt_file_prefix: str = "sonai_100k"):
     target_imagesTr = join(target_base, "imagesTr")
     target_imagesTs = join(target_base, "imagesTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_imagesTs)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_imagesTs)
 
     # Populate Target Directory
 

--- a/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
+++ b/yucca/pipeline/task_conversion/Task998_WMH_Dummy_Missing_Modalities.py
@@ -1,5 +1,5 @@
 import shutil
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfolders
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfolders
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 import numpy as np
@@ -25,10 +25,10 @@ def convert(path: str, subdir: str = "WMH"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     for dataset in datasets:

--- a/yucca/pipeline/task_conversion/template.py
+++ b/yucca/pipeline/task_conversion/template.py
@@ -1,7 +1,7 @@
 import shutil
 import gzip
 from sklearn.model_selection import train_test_split
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 from yucca.paths import get_raw_data_path
 
@@ -47,10 +47,10 @@ def convert(path: str, subdir: str = "MyDataset"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     """Populate Target Directory
     This is also the place to apply any re-orientation, resampling and/or label correction."""

--- a/yucca/pipeline/task_conversion/template_multiprocessing.py
+++ b/yucca/pipeline/task_conversion/template_multiprocessing.py
@@ -1,4 +1,4 @@
-from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p, subfiles
+from batchgenerators.utilities.file_and_folder_operations import join, maybe_mkdir_p as ensure_dir_exists, subfiles
 from yucca.pipeline.task_conversion.utils import generate_dataset_json
 import shutil
 import gzip
@@ -42,10 +42,10 @@ def convert(path: str, subdir: str = "DatasetName"):
     target_imagesTs = join(target_base, "imagesTs")
     target_labelsTs = join(target_base, "labelsTs")
 
-    maybe_mkdir_p(target_imagesTr)
-    maybe_mkdir_p(target_labelsTs)
-    maybe_mkdir_p(target_imagesTs)
-    maybe_mkdir_p(target_labelsTr)
+    ensure_dir_exists(target_imagesTr)
+    ensure_dir_exists(target_labelsTs)
+    ensure_dir_exists(target_imagesTs)
+    ensure_dir_exists(target_labelsTr)
 
     ###Populate Target Directory###
     # This is likely also the place to apply any re-orientation, resampling and/or label correction.

--- a/yucca/pipeline/task_conversion/utils.py
+++ b/yucca/pipeline/task_conversion/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import shutil
 import nibabel as nib
-from yucca.paths import get_preprocessed_data_path, get_raw_data_path
+from yucca.paths import get_models_path, get_preprocessed_data_path, get_raw_data_path
 from typing import Literal
 from batchgenerators.utilities.file_and_folder_operations import save_json, subfiles, join, subdirs
 from tqdm import tqdm
@@ -127,10 +127,16 @@ def generate_dataset_json(
 
 
 def get_task_from_task_id(task_id: str | int, stage: str):
-    assert stage in ["raw", "preprocessed"], stage
+    assert stage in ["raw", "preprocessed", "models"], stage
     task_id = str(task_id)
 
-    stage_path = get_raw_data_path() if stage == "raw" else get_preprocessed_data_path()
+    if stage == "raw":
+        stage_path = get_raw_data_path()
+    elif stage == "preprocessed":
+        stage_path = get_preprocessed_data_path()
+    elif stage == "models":
+        stage_path = get_models_path()
+
     tasks = subdirs(stage_path, join=False)
 
     # Check if name is already complete

--- a/yucca/pipeline/task_conversion/utils.py
+++ b/yucca/pipeline/task_conversion/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import shutil
 import nibabel as nib
-from yucca.paths import get_raw_data_path
+from yucca.paths import get_preprocessed_data_path, get_raw_data_path
 from typing import Literal
 from batchgenerators.utilities.file_and_folder_operations import save_json, subfiles, join, subdirs
 from tqdm import tqdm
@@ -126,9 +126,12 @@ def generate_dataset_json(
     save_json(json_dict, os.path.join(output_file))
 
 
-def maybe_get_task_from_task_id(task_id: str | int):
+def get_task_from_task_id(task_id: str | int, stage: str):
+    assert stage in ["raw", "preprocessed"], stage
     task_id = str(task_id)
-    tasks = subdirs(get_raw_data_path(), join=False)
+
+    stage_path = get_raw_data_path() if stage == "raw" else get_preprocessed_data_path()
+    tasks = subdirs(stage_path, join=False)
 
     # Check if name is already complete
     if task_id in tasks:
@@ -140,8 +143,4 @@ def maybe_get_task_from_task_id(task_id: str | int):
         if task_id.lower() in task.lower():
             return task
 
-    # If we can't find anything we just return the original, on the offchance that the task does not exist in Raw Data while existing in e.g. Preprocessed
-    print(
-        f"Couldn't find a task called: {task_id} in the raw data folder: {get_raw_data_path()}. If your task only exists in e.g. the Preprocessed folder things might still work."
-    )
-    return task_id
+    raise LookupError(f"Task {task_id} not found in {stage_path}.")


### PR DESCRIPTION
Fixes #82. Finally.

The following are renamed:

```python

maybe_mkdir_p ~> ensure_dir_exists
maybe_to_gpu ~> move_to_available_device (which fwiw breaks 'cpu' support on mps device, but this pr doesnt change that)
maybe_get_task_from_task_id -> get_task_from_task_id (including refactor!)
```

Not changed: 
```
load_and_maybe_keep_volume
load_and_maybe_keep_pickle
```