### PR TITLE
Implement minor metric improvements

### DIFF
--- a/yucca/modules/lightning_modules/YuccaLightningModule.py
+++ b/yucca/modules/lightning_modules/YuccaLightningModule.py
@@ -137,14 +137,21 @@ class YuccaLightningModule(BaseLightningModule):
                     "train/aggregated_dice": GeneralizedDiceScore(
                         multilabel=self.use_label_regions,
                         num_classes=self.num_classes,
-                        include_background=self.num_classes == 1,
+                        include_background=self.num_classes == 1 or self.use_label_regions,
                         weight_type="linear",
                         per_class=False,
+                    ),
+                    "train/mean_dice": GeneralizedDiceScore(
+                        multilabel=self.use_label_regions,
+                        num_classes=self.num_classes,
+                        include_background=self.num_classes == 1 or self.use_label_regions,
+                        weight_type="linear",
+                        average=True,
                     ),
                     "train/dice": GeneralizedDiceScore(
                         multilabel=self.use_label_regions,
                         num_classes=self.num_classes,
-                        include_background=self.num_classes == 1,
+                        include_background=self.num_classes == 1 or self.use_label_regions,
                         weight_type="linear",
                         per_class=True,
                     ),
@@ -156,14 +163,21 @@ class YuccaLightningModule(BaseLightningModule):
                     "val/aggregated_dice": GeneralizedDiceScore(
                         multilabel=self.use_label_regions,
                         num_classes=self.num_classes,
-                        include_background=self.num_classes == 1,
+                        include_background=self.num_classes == 1 or self.use_label_regions,
                         weight_type="linear",
                         per_class=False,
+                    ),
+                    "val/mean_dice": GeneralizedDiceScore(
+                        multilabel=self.use_label_regions,
+                        num_classes=self.num_classes,
+                        include_background=self.num_classes == 1 or self.use_label_regions,
+                        weight_type="linear",
+                        average=True,
                     ),
                     "val/dice": GeneralizedDiceScore(
                         multilabel=self.use_label_regions,
                         num_classes=self.num_classes,
-                        include_background=self.num_classes == 1,
+                        include_background=self.num_classes == 1 or self.use_label_regions,
                         weight_type="linear",
                         per_class=True,
                     ),
@@ -189,7 +203,7 @@ class YuccaLightningModule(BaseLightningModule):
             output = output[0]
             target = target[0]
 
-        metrics = self.compute_metrics(self.train_metrics, output, target)
+        metrics = self.compute_metrics(self.train_metrics, output, target, ignore_index=None if self.use_label_regions else 0)
         self.log_dict(
             {"train/loss": loss} | metrics,
             on_step=self.step_logging,
@@ -217,7 +231,7 @@ class YuccaLightningModule(BaseLightningModule):
         output = self(inputs)
         loss = self.loss_fn_val(output, target)
 
-        metrics = self.compute_metrics(self.val_metrics, output, target)
+        metrics = self.compute_metrics(self.val_metrics, output, target, ignore_index=None if self.use_label_regions else 0)
         self.log_dict(
             {"val/loss": loss} | metrics,
             on_step=self.step_logging,


### PR DESCRIPTION
This PR makes the following minor improvement to how metrics are calculated during training:

1. Calculate both aggregate and mean dice:

For class 1 and 2 respectively:

**Aggregate Dice:** Calculate $TP = TP_1 + TP_2$ and similar for FP and FN. Then $Dice = 2TP/(FP+FN)$.
**Mean Dice:**: $Dice = (Dice_1 + Dice_2) / 2$.

2. When using regions, also add dice of class 0 to wandb (that is, dont ignore index 0 when using regions)