### PR TITLE
Fix minor mistake in Preprocessor

### DIFF
--- a/yucca/functional/preprocessing.py
+++ b/yucca/functional/preprocessing.py
@@ -457,7 +457,7 @@ def preprocess_case_for_inference(
 
     for i in range(len(images)):
         images[i], padding = pad_to_size(images[i], patch_size)
-        print(padding)
+
     image_properties["padded_shape"] = np.array(images[0].shape)
     image_properties["padding"] = padding
 

--- a/yucca/pipeline/preprocessing/YuccaPreprocessor.py
+++ b/yucca/pipeline/preprocessing/YuccaPreprocessor.py
@@ -363,16 +363,16 @@ class YuccaPreprocessor(object):
         assert isinstance(images, (list, tuple)), "image(s) should be a list or tuple, even if only one " "image is passed"
         self.initialize_properties()
 
+        images = [
+            read_file_to_nifti_or_np(image[0]) if isinstance(image, tuple) else read_file_to_nifti_or_np(image)
+            for image in images
+        ]
+
         if patch_size is None:
             patch_size = (0,) * len(images[0].shape)
 
         if sliding_window_prediction is False:
             self.target_size = patch_size
-
-        images = [
-            read_file_to_nifti_or_np(image[0]) if isinstance(image, tuple) else read_file_to_nifti_or_np(image)
-            for image in images
-        ]
 
         images, image_properties = preprocess_case_for_inference(
             crop_to_nonzero=self.plans["crop_to_nonzero"],


### PR DESCRIPTION
Fixes the following error which appears when the preprocessor is run with flag `--preprocess_test`:

```
"""
Traceback (most recent call last):
  File "/opt/software/python/3.11.3/lib/python3.11/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/opt/software/python/3.11.3/lib/python3.11/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "/home/fgp998/yucca/yucca/pipeline/preprocessing/YuccaPreprocessor.py", line 257, in preprocess_test_subject
    images, image_props = self.preprocess_case_for_inference(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fgp998/yucca/yucca/pipeline/preprocessing/YuccaPreprocessor.py", line 367, in preprocess_case_for_inference
    patch_size = (0,) * len(images[0].shape)
                            ^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'shape'
```