### PR TITLE
Change python requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 description = "The modern framework for sandbox experimentation and out-of-the box machine learning on medical data."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
It seems the file `functional/transforms/masking.py` is using the following syntax

https://github.com/Sllambias/yucca/blob/792d169f51d52c79af356705909814594ee0b174/yucca/functional/transforms/masking.py#L20

.. which is only valid python after [PEP 646](https://peps.python.org/pep-0646/) introduced in Python 3.11. 

This PR changes yucca to formally require Python 311. 