### PR TITLE
fix: unpacking tuple inside brackets

### DIFF
--- a/yucca/functional/transforms/masking.py
+++ b/yucca/functional/transforms/masking.py
@@ -7,7 +7,7 @@ def mask_batch(batch, pixel_value, ratio, token_size):
     )
     # np.ceil to get a grid with exact or larger dims than the input image
     # later we will crop it to the desired dims
-    slices = [slice(0, shape) for shape in batch.shape[2:]]
+    slices = (slice(0, shape) for shape in batch.shape[2:])
     grid_dims = np.ceil(batch.shape[2:] / np.array(token_size)).astype(np.uint8)
 
     grid_flat = np.ones(np.prod(grid_dims))
@@ -17,5 +17,5 @@ def mask_batch(batch, pixel_value, ratio, token_size):
     for idx, size in enumerate(token_size):
         grid = np.repeat(grid, repeats=size, axis=idx)
 
-    batch[:, :, grid[*slices] == 0] = pixel_value
+    batch[:, :, grid[slices] == 0] = pixel_value
     return batch


### PR DESCRIPTION
unpacking tuples inside brackets leads to an exception and is unnecessary since `arr[:,:]` is shorthand for
`arr[(slice(None),slice(None))]`

received following exception

```
Traceback (most recent call last):
  File "/path/to/project/src/finetune.py", line 27, in <module>
    from yucca.modules.data.augmentation.YuccaAugmentationComposer import (
  File "/path/to/python_env/lib/python3.10/site-packages/yucca/modules/data/augmentation/YuccaAugmentationComposer.py", line 3, in <module>
    from yucca.modules.data.augmentation.transforms import (
  File "/path/to/python_env/lib/python3.10/site-packages/yucca/modules/data/augmentation/transforms/__init__.py", line 1, in <module>
    from yucca.modules.data.augmentation.transforms.BiasField import BiasField
  File "/path/to/python_env/lib/python3.10/site-packages/yucca/modules/data/augmentation/transforms/BiasField.py", line 3, in <module>
    from yucca.functional.transforms import bias_field
  File "/path/to/python_env/lib/python3.10/site-packages/yucca/functional/transforms/__init__.py", line 8, in <module>
    from yucca.functional.transforms.masking import mask_batch
  File "/path/to/python_env/lib/python3.10/site-packages/yucca/functional/transforms/masking.py", line 20
    batch[:, :, grid[*slices] == 0] = pixel_value
                  ^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```